### PR TITLE
Add new cities

### DIFF
--- a/img/uk_counties.svg
+++ b/img/uk_counties.svg
@@ -148,385 +148,285 @@
     </g>
   </g>
   <g id="Cities">
-    <g id="Somerset">
-      <g id="Bath">
-        <circle cx="63.13" cy="119.28" r="1"/>
-        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Wells">
-        <circle cx="60.87" cy="120.41" r="1"/>
-        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Bath">
+      <circle cx="63.13" cy="119.28" r="1"/>
+      <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Cornwall">
-      <g id="Truro">
-        <circle cx="42.77" cy="132.85" r="1"/>
-        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Truro">
+      <circle cx="42.77" cy="132.85" r="1"/>
+      <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Decon">
-      <g id="Plymouth">
-        <circle cx="50.12" cy="130.59" r="1"/>
-        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Exeter">
-        <circle cx="54.08" cy="127.2" r="1"/>
-        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Plymouth">
+      <circle cx="50.12" cy="130.59" r="1"/>
+      <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Wiltshire">
-      <g id="Salisbury">
-        <circle cx="67.66" cy="122.1" r="1"/>
-        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Exeter">
+      <circle cx="54.08" cy="127.2" r="1"/>
+      <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Hampshire">
-      <g id="Southampton">
-        <circle cx="71.5" cy="125" r="1"/>
-        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Portsmouth">
-        <circle cx="73.5" cy="125.5" r="1"/>
-        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Winchester">
-        <circle cx="72.3" cy="122.1" r="1"/>
-        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Wells">
+      <circle cx="60.87" cy="120.41" r="1"/>
+      <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="West Sussex">
-      <g id="Chichester">
-        <circle cx="75.58" cy="124.93" r="1"/>
-        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Salisbury">
+      <circle cx="67.66" cy="122.1" r="1"/>
+      <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="East Sussex">
-      <g id="Brighton and Hove">
-        <circle cx="80.67" cy="124.93" r="1"/>
-        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Southampton">
+      <circle cx="71.5" cy="125" r="1"/>
+      <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Kent">
-      <g id="Canterbury">
-        <circle cx="89.94" cy="119.84" r="1"/>
-        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Portsmouth">
+      <circle cx="73.5" cy="125.5" r="1"/>
+      <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Greater London">
-      <g id="City of Westminster">
-        <circle cx="79.54" cy="117.01" r="1"/>
-        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Chichester">
+      <circle cx="75.58" cy="124.93" r="1"/>
+      <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Oxfordshire">
-      <g id="Oxford">
-        <circle cx="71.62" cy="113.62" r="1"/>
-        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Winchester">
+      <circle cx="72.3" cy="122.1" r="1"/>
+      <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Hertfordshire">
-      <g id="St Albans">
-        <circle cx="78.97" cy="113.62" r="1"/>
-        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Brighton and Hove">
+      <circle cx="80.67" cy="124.93" r="1"/>
+      <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Essex">
-      <g id="Chelmsford">
-        <circle cx="85.19" cy="113.62" r="1"/>
-        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Colchester">
-        <circle cx="88.03" cy="112.06" r="1"/>
-        <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Southend-on-Sea">
-        <circle cx="86.81" cy="116.72" r="1"/>
-        <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Canterbury">
+      <circle cx="89.94" cy="119.84" r="1"/>
+      <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Gloucestershire">
-      <g id="Gloucester">
-        <circle cx="64.26" cy="113.05" r="1"/>
-        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="City of Westminster">
+      <circle cx="79.54" cy="117.01" r="1"/>
+      <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Dyfed">
-      <g id="St Davids">
-        <circle cx="43.67" cy="112.49" r="1"/>
-        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Southend-on-Sea">
+      <circle cx="86.81" cy="116.72" r="1"/>
+      <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Herefordshire">
-      <g id="Hereford">
-        <circle cx="61.1" cy="110.79" r="1"/>
-        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Oxford">
+      <circle cx="71.62" cy="113.62" r="1"/>
+      <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Worcestershire">
-      <g id="Worcester">
-        <circle cx="64.83" cy="109.09" r="1"/>
-        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="St Albans">
+      <circle cx="78.97" cy="113.62" r="1"/>
+      <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Cambridgeshire">
-      <g id="Cambridge">
-        <circle cx="81.23" cy="108.53" r="1"/>
-        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Ely">
-        <circle cx="81.57" cy="106.27" r="1"/>
-        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Peterborough">
-        <circle cx="78.97" cy="104" r="1"/>
-        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Chelmsford">
+      <circle cx="85.19" cy="113.62" r="1"/>
+      <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="West Midlands (county)">
-      <g id="Coventry">
-        <circle cx="69.35" cy="106.27" r="1"/>
-        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Birmingham">
-        <circle cx="67.09" cy="105.14" r="1"/>
-        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Wolverhampton">
-        <circle cx="65.39" cy="104" r="1"/>
-        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Newport">
+      <circle cx="58.04" cy="115.88" r="1"/>
+      <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g if="Norfolk">
-      <g id="Norwich">
-        <circle cx="89.72" cy="103.44" r="1"/>
-        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Cardiff">
+      <circle cx="56.91" cy="117.01" r="1"/>
+      <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Leicestershire">
-      <g id="Leicester">
-        <circle cx="72.52" cy="103.44" r="1"/>
-        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Swansea">
+      <circle cx="52.95" cy="114.75" r="1"/>
+      <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Staffordshire">
-      <g id="Lichfield">
-        <circle cx="67.88" cy="103.44" r="1"/>
-        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Stoke-on-Trent">
-        <circle cx="65.39" cy="98.91" r="1"/>
-        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Gloucester">
+      <circle cx="64.26" cy="113.05" r="1"/>
+      <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Nottinghamshire">
-      <g id="Nottingham">
-        <circle cx="72.52" cy="100.04" r="1"/>
-        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Colchester">
+      <circle cx="88.03" cy="112.06" r="1"/>
+      <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Derbyshire">
-      <g id="Derby">
-        <circle cx="69.92" cy="99.48" r="1"/>
-        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="St Davids">
+      <circle cx="43.67" cy="112.49" r="1"/>
+      <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Lincolnshire">
-      <g id="Lincoln">
-        <circle cx="77.27" cy="97.78" r="1"/>
-        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Milton Keynes">
+      <circle cx="75.50" cy="110.91" r="1"/>
+      <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="South Yorkshire">
-      <g id="Doncaster">
-        <circle cx="72.613" cy="92.65" r="1"/>
-        <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Sheffield">
-        <circle cx="69.35" cy="94.39" r="1"/>
-        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Hereford">
+      <circle cx="61.1" cy="110.79" r="1"/>
+      <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Greater Manchester">
-      <g id="Manchester">
-        <circle cx="64.83" cy="93.26" r="1"/>
-        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Salford">
-        <circle cx="63.92" cy="93.48" r="1"/>
-        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Worcester">
+      <circle cx="64.83" cy="109.09" r="1"/>
+      <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Merseyside">
-      <g id="Liverpool">
-        <circle cx="59.17" cy="94.39" r="1"/>
-        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Cambridge">
+      <circle cx="81.23" cy="108.53" r="1"/>
+      <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Cheshire">
-      <g id="Chester">
-        <circle cx="60.3" cy="96.65" r="1"/>
-        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Ely">
+      <circle cx="81.57" cy="106.27" r="1"/>
+      <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Clwyd">
-      <g id="St Asaph">
-        <circle cx="56.91" cy="96.65" r="1"/>
-        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Wrexham">
-        <circle cx="59.30" cy="97.79" r="1"/>
-        <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Coventry">
+      <circle cx="69.35" cy="106.27" r="1"/>
+      <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Gwynedd">
-      <g id="Bangor">
-        <circle cx="50.69" cy="96.65" r="1"/>
-        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Birmingham">
+      <circle cx="67.09" cy="105.14" r="1"/>
+      <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="East Riding of Yorkshire">
-      <g id="Kingston upon Hull">
-        <circle cx="78.4" cy="89.3" r="1"/>
-        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Wolverhampton">
+      <circle cx="65.39" cy="104" r="1"/>
+      <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="West Yorkshire">
-      <g id="Wakefield">
-        <circle cx="70.49" cy="90.99" r="1"/>
-        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Leeds">
-        <circle cx="69.35" cy="89.3" r="1"/>
-        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Bradford">
-        <circle cx="67.09" cy="89.3" r="1"/>
-        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Norwich">
+      <circle cx="89.72" cy="103.44" r="1"/>
+      <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Lancashire">
-      <g id="Preston">
-        <circle cx="61.43" cy="89.3" r="1"/>
-        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lancaster">
-        <circle cx="61.43" cy="86.47" r="1"/>
-        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Peterborough">
+      <circle cx="78.97" cy="104" r="1"/>
+      <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="North Yorkshire">
-      <g id="York">
-        <circle cx="72.75" cy="87.6" r="1"/>
-        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Ripon">
-        <circle cx="69.92" cy="85.34" r="1"/>
-        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Leicester">
+      <circle cx="72.52" cy="103.44" r="1"/>
+      <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="County Durham">
-      <g id="Durham">
-        <circle cx="69.35" cy="78.55" r="1"/>
-        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Lichfield">
+      <circle cx="67.88" cy="103.44" r="1"/>
+      <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Tyne and Wear">
-      <g id="Sunderland">
-        <circle cx="69.92" cy="76.29" r="1"/>
-        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newcastle upon Tyne">
-        <circle cx="68.79" cy="75.15" r="1"/>
-        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Nottingham">
+      <circle cx="72.52" cy="100.04" r="1"/>
+      <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Cumbria">
-      <g id="Carlisle">
-        <circle cx="60.3" cy="75.72" r="1"/>
-        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Derby">
+      <circle cx="69.92" cy="99.48" r="1"/>
+      <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Buckinghamshire">
-      <g id="Milton Keynes">
-        <circle cx="75.50" cy="110.91" r="1"/>
-        <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Stoke-on-Trent">
+      <circle cx="65.39" cy="98.91" r="1"/>
+      <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Gwent (county)">
-      <g id="Newport">
-        <circle cx="58.04" cy="115.88" r="1"/>
-        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Lincoln">
+      <circle cx="77.27" cy="97.78" r="1"/>
+      <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="South Glamorgan">
-      <g id="Cardiff">
-        <circle cx="56.91" cy="117.01" r="1"/>
-        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Sheffield">
+      <circle cx="69.35" cy="94.39" r="1"/>
+      <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="West Glamorgan">
-      <g id="Swansea">
-        <circle cx="52.95" cy="114.75" r="1"/>
-        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Doncaster">
+      <circle cx="72.613" cy="92.65" r="1"/>
+      <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Stirling (council area)">
-      <g id="Stirling">
-        <circle cx="51.35" cy="61.00" r="1"/>
-        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Manchester">
+      <circle cx="64.83" cy="93.26" r="1"/>
+      <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Perth and Kinross">
-      <g id="Perth">
-        <circle cx="54.72" cy="58.42" r="1"/>
-        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Salford">
+      <circle cx="63.92" cy="93.48" r="1"/>
+      <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Highland (council area)">
-      <g id="Inverness">
-        <circle cx="49.39" cy="44.2" r="1"/>
-        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Liverpool">
+      <circle cx="59.17" cy="94.39" r="1"/>
+      <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="Fife">
-      <g id="Dunfermline">
-        <circle cx="55.61" cy="61.85" r="1"/>
-        <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Chester">
+      <circle cx="60.3" cy="96.65" r="1"/>
+      <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="County Down">
-      <g id="Bangor">
-        <circle cx="39.00" cy="79.86" r="1"/>
-        <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="St Asaph">
+      <circle cx="56.91" cy="96.65" r="1"/>
+      <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="County Londonderry">
-      <g id="Derry">
-        <circle cx="27.11" cy="75.92" r="1"/>
-        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Wrexham">
+      <circle cx="59.30" cy="97.79" r="1"/>
+      <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="County Armagh / County Down">
-      <g id="Newry">
-        <circle cx="33.87" cy="86.58" r="1"/>
-        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Bangor, Gwynedd">
+      <circle cx="50.69" cy="96.65" r="1"/>
+      <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="County Armagh">
-      <g id="Armagh">
-        <circle cx="31.45" cy="84.59" r="1"/>
-        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Kingston upon Hull">
+      <circle cx="78.4" cy="89.3" r="1"/>
+      <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
-    <g id="County Antrim / County Down">
-      <g id="Belfast">
-        <circle cx="36.41" cy="80.88" r="1"/>
-        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lisburn">
-        <circle cx="34.64" cy="81.71" r="1"/>
-        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
+    <g id="Wakefield">
+      <circle cx="70.49" cy="90.99" r="1"/>
+      <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Leeds">
+      <circle cx="69.35" cy="89.3" r="1"/>
+      <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Bradford">
+      <circle cx="67.09" cy="89.3" r="1"/>
+      <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Preston">
+      <circle cx="61.43" cy="89.3" r="1"/>
+      <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Lancaster">
+      <circle cx="61.43" cy="86.47" r="1"/>
+      <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="York">
+      <circle cx="72.75" cy="87.6" r="1"/>
+      <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Ripon">
+      <circle cx="69.92" cy="85.34" r="1"/>
+      <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Durham">
+      <circle cx="69.35" cy="78.55" r="1"/>
+      <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Sunderland">
+      <circle cx="69.92" cy="76.29" r="1"/>
+      <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Newcastle upon Tyne">
+      <circle cx="68.79" cy="75.15" r="1"/>
+      <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Carlisle">
+      <circle cx="60.3" cy="75.72" r="1"/>
+      <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Dunfermline">
+      <circle cx="55.61" cy="61.85" r="1"/>
+      <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Stirling">
+      <circle cx="51.35" cy="61.00" r="1"/>
+      <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Perth">
+      <circle cx="54.72" cy="58.42" r="1"/>
+      <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Inverness">
+      <circle cx="49.39" cy="44.2" r="1"/>
+      <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Derry">
+      <circle cx="27.11" cy="75.92" r="1"/>
+      <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Newry">
+      <circle cx="33.87" cy="86.58" r="1"/>
+      <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Bangor, County Down">
+      <circle cx="39.00" cy="79.86" r="1"/>
+      <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Armagh">
+      <circle cx="31.45" cy="84.59" r="1"/>
+      <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Belfast">
+      <circle cx="36.41" cy="80.88" r="1"/>
+      <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    </g>
+    <g id="Lisburn">
+      <circle cx="34.64" cy="81.71" r="1"/>
+      <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
     </g>
   </g>
   <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/img/uk_counties.svg
+++ b/img/uk_counties.svg
@@ -235,6 +235,14 @@
         <circle cx="85.19" cy="113.62" r="1"/>
         <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
+      <g id="Colchester">
+        <circle cx="88.03" cy="112.06" r="1"/>
+        <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Southend-on-Sea">
+        <circle cx="86.81" cy="116.72" r="1"/>
+        <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
     <g id="Gloucestershire">
       <g id="Gloucester">
@@ -329,6 +337,10 @@
       </g>
     </g>
     <g id="South Yorkshire">
+      <g id="Doncaster">
+        <circle cx="72.613" cy="92.65" r="1"/>
+        <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
       <g id="Sheffield">
         <circle cx="69.35" cy="94.39" r="1"/>
         <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -360,6 +372,10 @@
       <g id="St Asaph">
         <circle cx="56.91" cy="96.65" r="1"/>
         <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Wrexham">
+        <circle cx="59.30" cy="97.79" r="1"/>
+        <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
     </g>
     <g id="Gwynedd">
@@ -430,6 +446,12 @@
         <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
     </g>
+    <g id="Buckinghamshire">
+      <g id="Milton Keynes">
+        <circle cx="75.50" cy="110.91" r="1"/>
+        <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+    </g>
     <g id="Gwent (county)">
       <g id="Newport">
         <circle cx="58.04" cy="115.88" r="1"/>
@@ -464,6 +486,18 @@
       <g id="Inverness">
         <circle cx="49.39" cy="44.2" r="1"/>
         <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+    </g>
+    <g id="Fife">
+      <g id="Dunfermline">
+        <circle cx="55.61" cy="61.85" r="1"/>
+        <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+    </g>
+    <g id="County Down">
+      <g id="Bangor">
+        <circle cx="39.00" cy="79.86" r="1"/>
+        <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
     </g>
     <g id="County Londonderry">

--- a/img/uk_counties.svg
+++ b/img/uk_counties.svg
@@ -148,257 +148,351 @@
     </g>
   </g>
   <g id="Cities">
-    <g id="Bath">
-      <circle cx="63.13" cy="119.28" r="1"/>
-      <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Somerset">
+      <g id="Bath">
+        <circle cx="63.13" cy="119.28" r="1"/>
+        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Wells">
+        <circle cx="60.87" cy="120.41" r="1"/>
+        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Truro">
-      <circle cx="42.77" cy="132.85" r="1"/>
-      <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Cornwall">
+      <g id="Truro">
+        <circle cx="42.77" cy="132.85" r="1"/>
+        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Plymouth">
-      <circle cx="50.12" cy="130.59" r="1"/>
-      <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Decon">
+      <g id="Plymouth">
+        <circle cx="50.12" cy="130.59" r="1"/>
+        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Exeter">
+        <circle cx="54.08" cy="127.2" r="1"/>
+        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Exeter">
-      <circle cx="54.08" cy="127.2" r="1"/>
-      <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Wiltshire">
+      <g id="Salisbury">
+        <circle cx="67.66" cy="122.1" r="1"/>
+        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Wells">
-      <circle cx="60.87" cy="120.41" r="1"/>
-      <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Hampshire">
+      <g id="Southampton">
+        <circle cx="71.5" cy="125" r="1"/>
+        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Portsmouth">
+        <circle cx="73.5" cy="125.5" r="1"/>
+        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Winchester">
+        <circle cx="72.3" cy="122.1" r="1"/>
+        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Salisbury">
-      <circle cx="67.66" cy="122.1" r="1"/>
-      <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="West Sussex">
+      <g id="Chichester">
+        <circle cx="75.58" cy="124.93" r="1"/>
+        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Southampton">
-      <circle cx="71.5" cy="125" r="1"/>
-      <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="East Sussex">
+      <g id="Brighton and Hove">
+        <circle cx="80.67" cy="124.93" r="1"/>
+        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Portsmouth">
-      <circle cx="73.5" cy="125.5" r="1"/>
-      <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Kent">
+      <g id="Canterbury">
+        <circle cx="89.94" cy="119.84" r="1"/>
+        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Chichester">
-      <circle cx="75.58" cy="124.93" r="1"/>
-      <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Greater London">
+      <g id="City of Westminster">
+        <circle cx="79.54" cy="117.01" r="1"/>
+        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Winchester">
-      <circle cx="72.3" cy="122.1" r="1"/>
-      <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Oxfordshire">
+      <g id="Oxford">
+        <circle cx="71.62" cy="113.62" r="1"/>
+        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Brighton and Hove">
-      <circle cx="80.67" cy="124.93" r="1"/>
-      <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Hertfordshire">
+      <g id="St Albans">
+        <circle cx="78.97" cy="113.62" r="1"/>
+        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Canterbury">
-      <circle cx="89.94" cy="119.84" r="1"/>
-      <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Essex">
+      <g id="Chelmsford">
+        <circle cx="85.19" cy="113.62" r="1"/>
+        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="City of Westminster">
-      <circle cx="79.54" cy="117.01" r="1"/>
-      <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Gloucestershire">
+      <g id="Gloucester">
+        <circle cx="64.26" cy="113.05" r="1"/>
+        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Oxford">
-      <circle cx="71.62" cy="113.62" r="1"/>
-      <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Dyfed">
+      <g id="St Davids">
+        <circle cx="43.67" cy="112.49" r="1"/>
+        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="St Albans">
-      <circle cx="78.97" cy="113.62" r="1"/>
-      <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Herefordshire">
+      <g id="Hereford">
+        <circle cx="61.1" cy="110.79" r="1"/>
+        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Chelmsford">
-      <circle cx="85.19" cy="113.62" r="1"/>
-      <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Worcestershire">
+      <g id="Worcester">
+        <circle cx="64.83" cy="109.09" r="1"/>
+        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Newport">
-      <circle cx="58.04" cy="115.88" r="1"/>
-      <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Cambridgeshire">
+      <g id="Cambridge">
+        <circle cx="81.23" cy="108.53" r="1"/>
+        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Ely">
+        <circle cx="81.57" cy="106.27" r="1"/>
+        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Peterborough">
+        <circle cx="78.97" cy="104" r="1"/>
+        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Cardiff">
-      <circle cx="56.91" cy="117.01" r="1"/>
-      <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="West Midlands (county)">
+      <g id="Coventry">
+        <circle cx="69.35" cy="106.27" r="1"/>
+        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Birmingham">
+        <circle cx="67.09" cy="105.14" r="1"/>
+        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Wolverhampton">
+        <circle cx="65.39" cy="104" r="1"/>
+        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Swansea">
-      <circle cx="52.95" cy="114.75" r="1"/>
-      <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g if="Norfolk">
+      <g id="Norwich">
+        <circle cx="89.72" cy="103.44" r="1"/>
+        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Gloucester">
-      <circle cx="64.26" cy="113.05" r="1"/>
-      <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Leicestershire">
+      <g id="Leicester">
+        <circle cx="72.52" cy="103.44" r="1"/>
+        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="St Davids">
-      <circle cx="43.67" cy="112.49" r="1"/>
-      <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Staffordshire">
+      <g id="Lichfield">
+        <circle cx="67.88" cy="103.44" r="1"/>
+        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Stoke-on-Trent">
+        <circle cx="65.39" cy="98.91" r="1"/>
+        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Hereford">
-      <circle cx="61.1" cy="110.79" r="1"/>
-      <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Nottinghamshire">
+      <g id="Nottingham">
+        <circle cx="72.52" cy="100.04" r="1"/>
+        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Worcester">
-      <circle cx="64.83" cy="109.09" r="1"/>
-      <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Derbyshire">
+      <g id="Derby">
+        <circle cx="69.92" cy="99.48" r="1"/>
+        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Cambridge">
-      <circle cx="81.23" cy="108.53" r="1"/>
-      <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Lincolnshire">
+      <g id="Lincoln">
+        <circle cx="77.27" cy="97.78" r="1"/>
+        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Ely">
-      <circle cx="81.57" cy="106.27" r="1"/>
-      <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="South Yorkshire">
+      <g id="Sheffield">
+        <circle cx="69.35" cy="94.39" r="1"/>
+        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Coventry">
-      <circle cx="69.35" cy="106.27" r="1"/>
-      <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Greater Manchester">
+      <g id="Manchester">
+        <circle cx="64.83" cy="93.26" r="1"/>
+        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Salford">
+        <circle cx="63.92" cy="93.48" r="1"/>
+        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Birmingham">
-      <circle cx="67.09" cy="105.14" r="1"/>
-      <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Merseyside">
+      <g id="Liverpool">
+        <circle cx="59.17" cy="94.39" r="1"/>
+        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Wolverhampton">
-      <circle cx="65.39" cy="104" r="1"/>
-      <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Cheshire">
+      <g id="Chester">
+        <circle cx="60.3" cy="96.65" r="1"/>
+        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Norwich">
-      <circle cx="89.72" cy="103.44" r="1"/>
-      <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Clwyd">
+      <g id="St Asaph">
+        <circle cx="56.91" cy="96.65" r="1"/>
+        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Peterborough">
-      <circle cx="78.97" cy="104" r="1"/>
-      <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Gwynedd">
+      <g id="Bangor">
+        <circle cx="50.69" cy="96.65" r="1"/>
+        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Leicester">
-      <circle cx="72.52" cy="103.44" r="1"/>
-      <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="East Riding of Yorkshire">
+      <g id="Kingston upon Hull">
+        <circle cx="78.4" cy="89.3" r="1"/>
+        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Lichfield">
-      <circle cx="67.88" cy="103.44" r="1"/>
-      <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="West Yorkshire">
+      <g id="Wakefield">
+        <circle cx="70.49" cy="90.99" r="1"/>
+        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Leeds">
+        <circle cx="69.35" cy="89.3" r="1"/>
+        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bradford">
+        <circle cx="67.09" cy="89.3" r="1"/>
+        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Nottingham">
-      <circle cx="72.52" cy="100.04" r="1"/>
-      <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Lancashire">
+      <g id="Preston">
+        <circle cx="61.43" cy="89.3" r="1"/>
+        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lancaster">
+        <circle cx="61.43" cy="86.47" r="1"/>
+        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Derby">
-      <circle cx="69.92" cy="99.48" r="1"/>
-      <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="North Yorkshire">
+      <g id="York">
+        <circle cx="72.75" cy="87.6" r="1"/>
+        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Ripon">
+        <circle cx="69.92" cy="85.34" r="1"/>
+        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Stoke-on-Trent">
-      <circle cx="65.39" cy="98.91" r="1"/>
-      <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="County Durham">
+      <g id="Durham">
+        <circle cx="69.35" cy="78.55" r="1"/>
+        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Lincoln">
-      <circle cx="77.27" cy="97.78" r="1"/>
-      <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Tyne and Wear">
+      <g id="Sunderland">
+        <circle cx="69.92" cy="76.29" r="1"/>
+        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newcastle upon Tyne">
+        <circle cx="68.79" cy="75.15" r="1"/>
+        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Sheffield">
-      <circle cx="69.35" cy="94.39" r="1"/>
-      <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Cumbria">
+      <g id="Carlisle">
+        <circle cx="60.3" cy="75.72" r="1"/>
+        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Manchester">
-      <circle cx="64.83" cy="93.26" r="1"/>
-      <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Gwent (county)">
+      <g id="Newport">
+        <circle cx="58.04" cy="115.88" r="1"/>
+        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Salford">
-      <circle cx="63.92" cy="93.48" r="1"/>
-      <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="South Glamorgan">
+      <g id="Cardiff">
+        <circle cx="56.91" cy="117.01" r="1"/>
+        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Liverpool">
-      <circle cx="59.17" cy="94.39" r="1"/>
-      <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="West Glamorgan">
+      <g id="Swansea">
+        <circle cx="52.95" cy="114.75" r="1"/>
+        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Chester">
-      <circle cx="60.3" cy="96.65" r="1"/>
-      <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Stirling (council area)">
+      <g id="Stirling">
+        <circle cx="51.35" cy="61.00" r="1"/>
+        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="St Asaph">
-      <circle cx="56.91" cy="96.65" r="1"/>
-      <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Perth and Kinross">
+      <g id="Perth">
+        <circle cx="54.72" cy="58.42" r="1"/>
+        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Bangor">
-      <circle cx="50.69" cy="96.65" r="1"/>
-      <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="Highland (council area)">
+      <g id="Inverness">
+        <circle cx="49.39" cy="44.2" r="1"/>
+        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Kingston upon Hull">
-      <circle cx="78.4" cy="89.3" r="1"/>
-      <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="County Londonderry">
+      <g id="Derry">
+        <circle cx="27.11" cy="75.92" r="1"/>
+        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Wakefield">
-      <circle cx="70.49" cy="90.99" r="1"/>
-      <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="County Armagh / County Down">
+      <g id="Newry">
+        <circle cx="33.87" cy="86.58" r="1"/>
+        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Leeds">
-      <circle cx="69.35" cy="89.3" r="1"/>
-      <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="County Armagh">
+      <g id="Armagh">
+        <circle cx="31.45" cy="84.59" r="1"/>
+        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
-    <g id="Bradford">
-      <circle cx="67.09" cy="89.3" r="1"/>
-      <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Preston">
-      <circle cx="61.43" cy="89.3" r="1"/>
-      <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Lancaster">
-      <circle cx="61.43" cy="86.47" r="1"/>
-      <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="York">
-      <circle cx="72.75" cy="87.6" r="1"/>
-      <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Ripon">
-      <circle cx="69.92" cy="85.34" r="1"/>
-      <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Durham">
-      <circle cx="69.35" cy="78.55" r="1"/>
-      <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Sunderland">
-      <circle cx="69.92" cy="76.29" r="1"/>
-      <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Newcastle upon Tyne">
-      <circle cx="68.79" cy="75.15" r="1"/>
-      <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Carlisle">
-      <circle cx="60.3" cy="75.72" r="1"/>
-      <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Stirling">
-      <circle cx="51.35" cy="61.00" r="1"/>
-      <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Perth">
-      <circle cx="54.72" cy="58.42" r="1"/>
-      <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Inverness">
-      <circle cx="49.39" cy="44.2" r="1"/>
-      <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Derry">
-      <circle cx="27.11" cy="75.92" r="1"/>
-      <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Newry">
-      <circle cx="33.87" cy="86.58" r="1"/>
-      <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Armagh">
-      <circle cx="31.45" cy="84.59" r="1"/>
-      <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Belfast">
-      <circle cx="36.41" cy="80.88" r="1"/>
-      <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-    </g>
-    <g id="Lisburn">
-      <circle cx="34.64" cy="81.71" r="1"/>
-      <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+    <g id="County Antrim / County Down">
+      <g id="Belfast">
+        <circle cx="36.41" cy="80.88" r="1"/>
+        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lisburn">
+        <circle cx="34.64" cy="81.71" r="1"/>
+        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
     </g>
   </g>
   <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/recipes/UK_Geog/source_to_crowdanki.yaml
+++ b/recipes/UK_Geog/source_to_crowdanki.yaml
@@ -30,12 +30,15 @@
             County: County
             Region: Region
             BoW: BoW
+            Info: Info
 
           personal_fields: [ ]
 
       file_mappings:
         - file: src/data/uk_geog.csv
           note_model: UK Geog
+          derivatives:
+            - file: src/data/city_info.csv
 
 
 - generate_crowd_anki:

--- a/src/data/cities.csv
+++ b/src/data/cities.csv
@@ -10,8 +10,10 @@ Carlisle,Cumbria
 Chelmsford,Essex
 Chester,Cheshire
 Chichester,West Sussex
+Colchester,Essex
 Coventry,West Midlands (county)
 Derby,Derbyshire
+Doncaster,South Yorkshire
 Durham,County Durham
 Ely,Cambridgeshire
 Exeter,Devon
@@ -26,6 +28,7 @@ Lincoln,Lincolnshire
 Liverpool,Merseyside
 City of London,City of London
 Manchester,Greater Manchester
+Milton Keynes,Buckinghamshire
 Newcastle upon Tyne,Tyne and Wear
 Norwich,Norfolk
 Nottingham,Nottinghamshire
@@ -39,6 +42,7 @@ Salford,Greater Manchester
 Salisbury,Wiltshire
 Sheffield,South Yorkshire
 Southampton,Hampshire
+Southend-on-Sea,Essex
 St Albans,Hertfordshire
 Stoke-on-Trent,Staffordshire
 Sunderland,Tyne and Wear
@@ -52,6 +56,7 @@ Worcester,Worcestershire
 York,North Yorkshire
 Aberdeen,Aberdeen
 Dundee,Dundee
+Dunfermline,Fife
 Edinburgh,Edinburgh
 Glasgow,Glasgow
 Inverness,Highland (council area)
@@ -63,7 +68,9 @@ Newport,Gwent (county)
 St Asaph,Clwyd
 St Davids,Dyfed
 Swansea,West Glamorgan
+Wrexham,Clwyd
 Armagh,County Armagh
+Bangor,County Down
 Belfast,County Antrim / County Down
 Lisburn,County Antrim / County Down
 Newry,County Armagh / County Down

--- a/src/data/city_info.csv
+++ b/src/data/city_info.csv
@@ -1,0 +1,3 @@
+city,macrolocation,info
+Bangor,Gwynedd,City status from time immemorial
+Bangor,County Down,Granted city status in 2022

--- a/src/data/uk_geog.csv
+++ b/src/data/uk_geog.csv
@@ -132,8 +132,10 @@ $f1OOoDy7|,Cambridge,Cambridgeshire,Cambridge,,,,City England
 -zEn?RsI)e,Chelmsford,Essex,Chelmsford,,,,City England
 6&*!x?2]xN,Chester,Cheshire,Chester,,,,City England
 (HwAH4YZ|z,Chichester,West Sussex,Chichester,,,,City England
+PIOCl^cTDW,Colchester,Essex,Colchester,,,,City England
 ",Ceoau}%UB",Coventry,West Midlands (county),Coventry,,,,City England
 "7$bL1NE7E,",Derby,Derbyshire,Derby,,,,City England
+Em=$3H^1SK,Doncaster,South Yorkshire,Doncaster,,,,City England
 8:82_UAiYs,Durham,County Durham,Durham,,,,City England
 !OL>3U6i8g,Ely,Cambridgeshire,Ely,,,,City England
 ",SspF`#/90",Exeter,Devon,Exeter,,,,City England
@@ -148,6 +150,7 @@ $f1OOoDy7|,Cambridge,Cambridgeshire,Cambridge,,,,City England
 9|q#D0Av/U,Liverpool,Merseyside,Liverpool,,,,City England
 :eUZI@RSa),City of London,City of London,City of London,,,,City England
 ",c=.xV>pH6",Manchester,Greater Manchester,Manchester,,,,City England
+toiOvw89v0,Milton Keynes,Buckinghamshire,Milton Keynes,,,,City England
 6;]RQG0$v3,Newcastle upon Tyne,Tyne and Wear,Newcastle upon Tyne,,,,City England
 "6;cn#,g6)",Norwich,Norfolk,Norwich,,,,City England
 &Zb4UTzkTe,Nottingham,Nottinghamshire,Nottingham,,,,City England
@@ -161,6 +164,7 @@ $G5u}H<e)P,Oxford,Oxfordshire,Oxford,,,,City England
 YsiUdkEyK,Salisbury,Wiltshire,Salisbury,,,,City England
 1M>#Uj)_H,Sheffield,South Yorkshire,Sheffield,,,,City England
 :pq<fu+W.k,Southampton,Hampshire,Southampton,,,,City England
+k}@E_;}<s7,Southend-on-Sea,Essex,Southend-on-Sea,,,,City England
 :fqG;gkI0@,St Albans,Hertfordshire,St Albans,,,,City England
 9JaD?`sI(%,Stoke-on-Trent,Staffordshire,Stoke-on-Trent,,,,City England
 8P@Im*:G5h,Sunderland,Tyne and Wear,Sunderland,,,,City England
@@ -174,6 +178,7 @@ YsiUdkEyK,Salisbury,Wiltshire,Salisbury,,,,City England
 72ISpU(o1`,York,North Yorkshire,York,,,,City England
 :fPt*k%~M(,Aberdeen,Aberdeen,Aberdeen,,,,City Scotland
 6IQ&Z1MKmD,Dundee,Dundee,Dundee,,,,City Scotland
+A@hlXllDB{,Dunfermline,Fife,Dunfermline,,,,City Scotland
 <[8d=W^vU[,Edinburgh,Edinburgh,Edinburgh,,,,City Scotland
 ;f_<G([>=3,Glasgow,Glasgow,Glasgow,,,,City Scotland
 %p(3NzC<-M,Inverness,Highland (council area),Inverness,,,,City Scotland
@@ -185,7 +190,9 @@ sz7^%6`]9,Stirling,Stirling (council area),Stirling,,,,City Scotland
 96mBI5Kn1t,St Asaph,Clwyd,St Asaph,,,,City Wales
 ;+?7VH}tAM,St Davids,Dyfed,St Davids,,,,City Wales
 6Bcp~`]_c),Swansea,West Glamorgan,Swansea,,,,City Wales
+g(PGEBLr`=,Wrexham,Clwyd,Wrexham,,,,City Wales
 .k7~sc;_46,Armagh,County Armagh,Armagh,,,,City NorthernIreland
+MO-xX;Y}$k,Bangor,County Down,Bangor,,,,City NorthernIreland
 ;/ZR/k5*b1,Belfast,County Antrim / County Down,Belfast,,,,City NorthernIreland
 :`g).pkAkW,Lisburn,County Antrim / County Down,Lisburn,,,,City NorthernIreland
 $30c4/#dc~,Newry,County Armagh / County Down,Newry,,,,City NorthernIreland

--- a/src/data/uk_geog.csv
+++ b/src/data/uk_geog.csv
@@ -184,7 +184,7 @@ A@hlXllDB{,Dunfermline,Fife,Dunfermline,,,,City Scotland
 %p(3NzC<-M,Inverness,Highland (council area),Inverness,,,,City Scotland
 &B{eu2o.{H,Perth,Perth and Kinross,Perth,,,,City Scotland
 sz7^%6`]9,Stirling,Stirling (council area),Stirling,,,,City Scotland
-:qMF=!p0S$,Bangor,Gwynedd,Bangor,,,,City Wales
+:qMF=!p0S$,"Bangor, Gwynedd",Gwynedd,Bangor,,,,City Wales
 -.f+8~_+P9,Cardiff,South Glamorgan,Cardiff,,,,City Wales
 =I]#oH4xjB,Newport,Gwent (county),Newport,,,,City Wales
 96mBI5Kn1t,St Asaph,Clwyd,St Asaph,,,,City Wales
@@ -192,7 +192,7 @@ sz7^%6`]9,Stirling,Stirling (council area),Stirling,,,,City Scotland
 6Bcp~`]_c),Swansea,West Glamorgan,Swansea,,,,City Wales
 g(PGEBLr`=,Wrexham,Clwyd,Wrexham,,,,City Wales
 .k7~sc;_46,Armagh,County Armagh,Armagh,,,,City NorthernIreland
-MO-xX;Y}$k,Bangor,County Down,Bangor,,,,City NorthernIreland
+MO-xX;Y}$k,"Bangor, County Down",County Down,Bangor,,,,City NorthernIreland
 ;/ZR/k5*b1,Belfast,County Antrim / County Down,Belfast,,,,City NorthernIreland
 :`g).pkAkW,Lisburn,County Antrim / County Down,Lisburn,,,,City NorthernIreland
 $30c4/#dc~,Newry,County Armagh / County Down,Newry,,,,City NorthernIreland

--- a/src/note_models/UK_Geog/note_models.yaml
+++ b/src/note_models/UK_Geog/note_models.yaml
@@ -8,6 +8,7 @@ fields:
   - name: County
   - name: Region
   - name: BoW
+  - name: Info
 templates:
   - name: BoW - Map
     html_file: src/note_models/UK_Geog/templates/Bow - Map.html

--- a/src/note_models/UK_Geog/templates/BoW - Map.html
+++ b/src/note_models/UK_Geog/templates/BoW - Map.html
@@ -163,385 +163,285 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Somerset">
-          <g id="Bath">
-            <circle cx="63.13" cy="119.28" r="1"/>
-            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wells">
-            <circle cx="60.87" cy="120.41" r="1"/>
-            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cornwall">
-          <g id="Truro">
-            <circle cx="42.77" cy="132.85" r="1"/>
-            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Decon">
-          <g id="Plymouth">
-            <circle cx="50.12" cy="130.59" r="1"/>
-            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Exeter">
-            <circle cx="54.08" cy="127.2" r="1"/>
-            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Wiltshire">
-          <g id="Salisbury">
-            <circle cx="67.66" cy="122.1" r="1"/>
-            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hampshire">
-          <g id="Southampton">
-            <circle cx="71.5" cy="125" r="1"/>
-            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Portsmouth">
-            <circle cx="73.5" cy="125.5" r="1"/>
-            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Winchester">
-            <circle cx="72.3" cy="122.1" r="1"/>
-            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Sussex">
-          <g id="Chichester">
-            <circle cx="75.58" cy="124.93" r="1"/>
-            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Sussex">
-          <g id="Brighton and Hove">
-            <circle cx="80.67" cy="124.93" r="1"/>
-            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Kent">
-          <g id="Canterbury">
-            <circle cx="89.94" cy="119.84" r="1"/>
-            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater London">
-          <g id="City of Westminster">
-            <circle cx="79.54" cy="117.01" r="1"/>
-            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Oxfordshire">
-          <g id="Oxford">
-            <circle cx="71.62" cy="113.62" r="1"/>
-            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hertfordshire">
-          <g id="St Albans">
-            <circle cx="78.97" cy="113.62" r="1"/>
-            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Essex">
-          <g id="Chelmsford">
-            <circle cx="85.19" cy="113.62" r="1"/>
-            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Colchester">
-            <circle cx="88.03" cy="112.06" r="1"/>
-            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Southend-on-Sea">
-            <circle cx="86.81" cy="116.72" r="1"/>
-            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gloucestershire">
-          <g id="Gloucester">
-            <circle cx="64.26" cy="113.05" r="1"/>
-            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Dyfed">
-          <g id="St Davids">
-            <circle cx="43.67" cy="112.49" r="1"/>
-            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Herefordshire">
-          <g id="Hereford">
-            <circle cx="61.1" cy="110.79" r="1"/>
-            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Worcestershire">
-          <g id="Worcester">
-            <circle cx="64.83" cy="109.09" r="1"/>
-            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cambridgeshire">
-          <g id="Cambridge">
-            <circle cx="81.23" cy="108.53" r="1"/>
-            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ely">
-            <circle cx="81.57" cy="106.27" r="1"/>
-            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Peterborough">
-            <circle cx="78.97" cy="104" r="1"/>
-            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Midlands (county)">
-          <g id="Coventry">
-            <circle cx="69.35" cy="106.27" r="1"/>
-            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Birmingham">
-            <circle cx="67.09" cy="105.14" r="1"/>
-            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wolverhampton">
-            <circle cx="65.39" cy="104" r="1"/>
-            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g if="Norfolk">
-          <g id="Norwich">
-            <circle cx="89.72" cy="103.44" r="1"/>
-            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Leicestershire">
-          <g id="Leicester">
-            <circle cx="72.52" cy="103.44" r="1"/>
-            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Staffordshire">
-          <g id="Lichfield">
-            <circle cx="67.88" cy="103.44" r="1"/>
-            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Stoke-on-Trent">
-            <circle cx="65.39" cy="98.91" r="1"/>
-            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Nottinghamshire">
-          <g id="Nottingham">
-            <circle cx="72.52" cy="100.04" r="1"/>
-            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Derbyshire">
-          <g id="Derby">
-            <circle cx="69.92" cy="99.48" r="1"/>
-            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lincolnshire">
-          <g id="Lincoln">
-            <circle cx="77.27" cy="97.78" r="1"/>
-            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Yorkshire">
-          <g id="Doncaster">
-            <circle cx="72.613" cy="92.65" r="1"/>
-            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Sheffield">
-            <circle cx="69.35" cy="94.39" r="1"/>
-            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater Manchester">
-          <g id="Manchester">
-            <circle cx="64.83" cy="93.26" r="1"/>
-            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Salford">
-            <circle cx="63.92" cy="93.48" r="1"/>
-            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Merseyside">
-          <g id="Liverpool">
-            <circle cx="59.17" cy="94.39" r="1"/>
-            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cheshire">
-          <g id="Chester">
-            <circle cx="60.3" cy="96.65" r="1"/>
-            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Clwyd">
-          <g id="St Asaph">
-            <circle cx="56.91" cy="96.65" r="1"/>
-            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wrexham">
-            <circle cx="59.30" cy="97.79" r="1"/>
-            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwynedd">
-          <g id="Bangor">
-            <circle cx="50.69" cy="96.65" r="1"/>
-            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Riding of Yorkshire">
-          <g id="Kingston upon Hull">
-            <circle cx="78.4" cy="89.3" r="1"/>
-            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Yorkshire">
-          <g id="Wakefield">
-            <circle cx="70.49" cy="90.99" r="1"/>
-            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Leeds">
-            <circle cx="69.35" cy="89.3" r="1"/>
-            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Bradford">
-            <circle cx="67.09" cy="89.3" r="1"/>
-            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lancashire">
-          <g id="Preston">
-            <circle cx="61.43" cy="89.3" r="1"/>
-            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lancaster">
-            <circle cx="61.43" cy="86.47" r="1"/>
-            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="North Yorkshire">
-          <g id="York">
-            <circle cx="72.75" cy="87.6" r="1"/>
-            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ripon">
-            <circle cx="69.92" cy="85.34" r="1"/>
-            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Durham">
-          <g id="Durham">
-            <circle cx="69.35" cy="78.55" r="1"/>
-            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Tyne and Wear">
-          <g id="Sunderland">
-            <circle cx="69.92" cy="76.29" r="1"/>
-            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newcastle upon Tyne">
-            <circle cx="68.79" cy="75.15" r="1"/>
-            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cumbria">
-          <g id="Carlisle">
-            <circle cx="60.3" cy="75.72" r="1"/>
-            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Buckinghamshire">
-          <g id="Milton Keynes">
-            <circle cx="75.50" cy="110.91" r="1"/>
-            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwent (county)">
-          <g id="Newport">
-            <circle cx="58.04" cy="115.88" r="1"/>
-            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Glamorgan">
-          <g id="Cardiff">
-            <circle cx="56.91" cy="117.01" r="1"/>
-            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Glamorgan">
-          <g id="Swansea">
-            <circle cx="52.95" cy="114.75" r="1"/>
-            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Stirling (council area)">
-          <g id="Stirling">
-            <circle cx="51.35" cy="61.00" r="1"/>
-            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Perth and Kinross">
-          <g id="Perth">
-            <circle cx="54.72" cy="58.42" r="1"/>
-            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Highland (council area)">
-          <g id="Inverness">
-            <circle cx="49.39" cy="44.2" r="1"/>
-            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Fife">
-          <g id="Dunfermline">
-            <circle cx="55.61" cy="61.85" r="1"/>
-            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Down">
-          <g id="Bangor">
-            <circle cx="39.00" cy="79.86" r="1"/>
-            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Londonderry">
-          <g id="Derry">
-            <circle cx="27.11" cy="75.92" r="1"/>
-            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh / County Down">
-          <g id="Newry">
-            <circle cx="33.87" cy="86.58" r="1"/>
-            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bangor, Gwynedd">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh">
-          <g id="Armagh">
-            <circle cx="31.45" cy="84.59" r="1"/>
-            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Antrim / County Down">
-          <g id="Belfast">
-            <circle cx="36.41" cy="80.88" r="1"/>
-            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lisburn">
-            <circle cx="34.64" cy="81.71" r="1"/>
-            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bangor, County Down">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -717,385 +617,285 @@
       </g>
     </g>
     <g id="Cities">
-      <g id="Somerset">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Bath">
+        <circle cx="63.13" cy="119.28" r="1"/>
+        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cornwall">
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Truro">
+        <circle cx="42.77" cy="132.85" r="1"/>
+        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Decon">
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Plymouth">
+        <circle cx="50.12" cy="130.59" r="1"/>
+        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Wiltshire">
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Exeter">
+        <circle cx="54.08" cy="127.2" r="1"/>
+        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Hampshire">
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wells">
+        <circle cx="60.87" cy="120.41" r="1"/>
+        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Sussex">
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Salisbury">
+        <circle cx="67.66" cy="122.1" r="1"/>
+        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="East Sussex">
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Southampton">
+        <circle cx="71.5" cy="125" r="1"/>
+        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Kent">
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Portsmouth">
+        <circle cx="73.5" cy="125.5" r="1"/>
+        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Greater London">
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chichester">
+        <circle cx="75.58" cy="124.93" r="1"/>
+        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Oxfordshire">
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Winchester">
+        <circle cx="72.3" cy="122.1" r="1"/>
+        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Hertfordshire">
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Brighton and Hove">
+        <circle cx="80.67" cy="124.93" r="1"/>
+        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Essex">
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Colchester">
-          <circle cx="88.03" cy="112.06" r="1"/>
-          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Southend-on-Sea">
-          <circle cx="86.81" cy="116.72" r="1"/>
-          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Canterbury">
+        <circle cx="89.94" cy="119.84" r="1"/>
+        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gloucestershire">
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="City of Westminster">
+        <circle cx="79.54" cy="117.01" r="1"/>
+        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Dyfed">
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Southend-on-Sea">
+        <circle cx="86.81" cy="116.72" r="1"/>
+        <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Herefordshire">
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Oxford">
+        <circle cx="71.62" cy="113.62" r="1"/>
+        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Worcestershire">
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Albans">
+        <circle cx="78.97" cy="113.62" r="1"/>
+        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cambridgeshire">
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chelmsford">
+        <circle cx="85.19" cy="113.62" r="1"/>
+        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Midlands (county)">
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Newport">
+        <circle cx="58.04" cy="115.88" r="1"/>
+        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g if="Norfolk">
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Cardiff">
+        <circle cx="56.91" cy="117.01" r="1"/>
+        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Leicestershire">
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Swansea">
+        <circle cx="52.95" cy="114.75" r="1"/>
+        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Staffordshire">
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Gloucester">
+        <circle cx="64.26" cy="113.05" r="1"/>
+        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Nottinghamshire">
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Colchester">
+        <circle cx="88.03" cy="112.06" r="1"/>
+        <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Derbyshire">
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Davids">
+        <circle cx="43.67" cy="112.49" r="1"/>
+        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Lincolnshire">
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Milton Keynes">
+        <circle cx="75.50" cy="110.91" r="1"/>
+        <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="South Yorkshire">
-        <g id="Doncaster">
-          <circle cx="72.613" cy="92.65" r="1"/>
-          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Hereford">
+        <circle cx="61.1" cy="110.79" r="1"/>
+        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Greater Manchester">
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Worcester">
+        <circle cx="64.83" cy="109.09" r="1"/>
+        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Merseyside">
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Cambridge">
+        <circle cx="81.23" cy="108.53" r="1"/>
+        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cheshire">
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Ely">
+        <circle cx="81.57" cy="106.27" r="1"/>
+        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Clwyd">
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wrexham">
-          <circle cx="59.30" cy="97.79" r="1"/>
-          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Coventry">
+        <circle cx="69.35" cy="106.27" r="1"/>
+        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gwynedd">
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Birmingham">
+        <circle cx="67.09" cy="105.14" r="1"/>
+        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="East Riding of Yorkshire">
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wolverhampton">
+        <circle cx="65.39" cy="104" r="1"/>
+        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Yorkshire">
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Norwich">
+        <circle cx="89.72" cy="103.44" r="1"/>
+        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Lancashire">
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Peterborough">
+        <circle cx="78.97" cy="104" r="1"/>
+        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="North Yorkshire">
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Leicester">
+        <circle cx="72.52" cy="103.44" r="1"/>
+        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Durham">
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Lichfield">
+        <circle cx="67.88" cy="103.44" r="1"/>
+        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Tyne and Wear">
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Nottingham">
+        <circle cx="72.52" cy="100.04" r="1"/>
+        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cumbria">
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Derby">
+        <circle cx="69.92" cy="99.48" r="1"/>
+        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Buckinghamshire">
-        <g id="Milton Keynes">
-          <circle cx="75.50" cy="110.91" r="1"/>
-          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Stoke-on-Trent">
+        <circle cx="65.39" cy="98.91" r="1"/>
+        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gwent (county)">
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Lincoln">
+        <circle cx="77.27" cy="97.78" r="1"/>
+        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="South Glamorgan">
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Sheffield">
+        <circle cx="69.35" cy="94.39" r="1"/>
+        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Glamorgan">
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Doncaster">
+        <circle cx="72.613" cy="92.65" r="1"/>
+        <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Stirling (council area)">
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Manchester">
+        <circle cx="64.83" cy="93.26" r="1"/>
+        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Perth and Kinross">
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Salford">
+        <circle cx="63.92" cy="93.48" r="1"/>
+        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Highland (council area)">
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Liverpool">
+        <circle cx="59.17" cy="94.39" r="1"/>
+        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Fife">
-        <g id="Dunfermline">
-          <circle cx="55.61" cy="61.85" r="1"/>
-          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chester">
+        <circle cx="60.3" cy="96.65" r="1"/>
+        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Down">
-        <g id="Bangor">
-          <circle cx="39.00" cy="79.86" r="1"/>
-          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Asaph">
+        <circle cx="56.91" cy="96.65" r="1"/>
+        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Londonderry">
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wrexham">
+        <circle cx="59.30" cy="97.79" r="1"/>
+        <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Armagh / County Down">
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Bangor, Gwynedd">
+        <circle cx="50.69" cy="96.65" r="1"/>
+        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Armagh">
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Kingston upon Hull">
+        <circle cx="78.4" cy="89.3" r="1"/>
+        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Antrim / County Down">
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wakefield">
+        <circle cx="70.49" cy="90.99" r="1"/>
+        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Leeds">
+        <circle cx="69.35" cy="89.3" r="1"/>
+        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bradford">
+        <circle cx="67.09" cy="89.3" r="1"/>
+        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Preston">
+        <circle cx="61.43" cy="89.3" r="1"/>
+        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lancaster">
+        <circle cx="61.43" cy="86.47" r="1"/>
+        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="York">
+        <circle cx="72.75" cy="87.6" r="1"/>
+        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Ripon">
+        <circle cx="69.92" cy="85.34" r="1"/>
+        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Durham">
+        <circle cx="69.35" cy="78.55" r="1"/>
+        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Sunderland">
+        <circle cx="69.92" cy="76.29" r="1"/>
+        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newcastle upon Tyne">
+        <circle cx="68.79" cy="75.15" r="1"/>
+        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Carlisle">
+        <circle cx="60.3" cy="75.72" r="1"/>
+        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Dunfermline">
+        <circle cx="55.61" cy="61.85" r="1"/>
+        <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Stirling">
+        <circle cx="51.35" cy="61.00" r="1"/>
+        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Perth">
+        <circle cx="54.72" cy="58.42" r="1"/>
+        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Inverness">
+        <circle cx="49.39" cy="44.2" r="1"/>
+        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Derry">
+        <circle cx="27.11" cy="75.92" r="1"/>
+        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newry">
+        <circle cx="33.87" cy="86.58" r="1"/>
+        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bangor, County Down">
+        <circle cx="39.00" cy="79.86" r="1"/>
+        <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Armagh">
+        <circle cx="31.45" cy="84.59" r="1"/>
+        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Belfast">
+        <circle cx="36.41" cy="80.88" r="1"/>
+        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lisburn">
+        <circle cx="34.64" cy="81.71" r="1"/>
+        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
     </g>
     <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/BoW - Map.html
+++ b/src/note_models/UK_Geog/templates/BoW - Map.html
@@ -163,257 +163,351 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Somerset">
+          <g id="Bath">
+            <circle cx="63.13" cy="119.28" r="1"/>
+            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wells">
+            <circle cx="60.87" cy="120.41" r="1"/>
+            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cornwall">
+          <g id="Truro">
+            <circle cx="42.77" cy="132.85" r="1"/>
+            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Decon">
+          <g id="Plymouth">
+            <circle cx="50.12" cy="130.59" r="1"/>
+            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Exeter">
+            <circle cx="54.08" cy="127.2" r="1"/>
+            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Wiltshire">
+          <g id="Salisbury">
+            <circle cx="67.66" cy="122.1" r="1"/>
+            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hampshire">
+          <g id="Southampton">
+            <circle cx="71.5" cy="125" r="1"/>
+            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Portsmouth">
+            <circle cx="73.5" cy="125.5" r="1"/>
+            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Winchester">
+            <circle cx="72.3" cy="122.1" r="1"/>
+            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Sussex">
+          <g id="Chichester">
+            <circle cx="75.58" cy="124.93" r="1"/>
+            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Sussex">
+          <g id="Brighton and Hove">
+            <circle cx="80.67" cy="124.93" r="1"/>
+            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Kent">
+          <g id="Canterbury">
+            <circle cx="89.94" cy="119.84" r="1"/>
+            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater London">
+          <g id="City of Westminster">
+            <circle cx="79.54" cy="117.01" r="1"/>
+            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Oxfordshire">
+          <g id="Oxford">
+            <circle cx="71.62" cy="113.62" r="1"/>
+            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hertfordshire">
+          <g id="St Albans">
+            <circle cx="78.97" cy="113.62" r="1"/>
+            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Essex">
+          <g id="Chelmsford">
+            <circle cx="85.19" cy="113.62" r="1"/>
+            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gloucestershire">
+          <g id="Gloucester">
+            <circle cx="64.26" cy="113.05" r="1"/>
+            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Dyfed">
+          <g id="St Davids">
+            <circle cx="43.67" cy="112.49" r="1"/>
+            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Herefordshire">
+          <g id="Hereford">
+            <circle cx="61.1" cy="110.79" r="1"/>
+            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Worcestershire">
+          <g id="Worcester">
+            <circle cx="64.83" cy="109.09" r="1"/>
+            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cambridgeshire">
+          <g id="Cambridge">
+            <circle cx="81.23" cy="108.53" r="1"/>
+            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ely">
+            <circle cx="81.57" cy="106.27" r="1"/>
+            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Peterborough">
+            <circle cx="78.97" cy="104" r="1"/>
+            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Midlands (county)">
+          <g id="Coventry">
+            <circle cx="69.35" cy="106.27" r="1"/>
+            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Birmingham">
+            <circle cx="67.09" cy="105.14" r="1"/>
+            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wolverhampton">
+            <circle cx="65.39" cy="104" r="1"/>
+            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g if="Norfolk">
+          <g id="Norwich">
+            <circle cx="89.72" cy="103.44" r="1"/>
+            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Leicestershire">
+          <g id="Leicester">
+            <circle cx="72.52" cy="103.44" r="1"/>
+            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Staffordshire">
+          <g id="Lichfield">
+            <circle cx="67.88" cy="103.44" r="1"/>
+            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Stoke-on-Trent">
+            <circle cx="65.39" cy="98.91" r="1"/>
+            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Nottinghamshire">
+          <g id="Nottingham">
+            <circle cx="72.52" cy="100.04" r="1"/>
+            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Derbyshire">
+          <g id="Derby">
+            <circle cx="69.92" cy="99.48" r="1"/>
+            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lincolnshire">
+          <g id="Lincoln">
+            <circle cx="77.27" cy="97.78" r="1"/>
+            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Yorkshire">
+          <g id="Sheffield">
+            <circle cx="69.35" cy="94.39" r="1"/>
+            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater Manchester">
+          <g id="Manchester">
+            <circle cx="64.83" cy="93.26" r="1"/>
+            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Salford">
+            <circle cx="63.92" cy="93.48" r="1"/>
+            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Merseyside">
+          <g id="Liverpool">
+            <circle cx="59.17" cy="94.39" r="1"/>
+            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cheshire">
+          <g id="Chester">
+            <circle cx="60.3" cy="96.65" r="1"/>
+            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Clwyd">
+          <g id="St Asaph">
+            <circle cx="56.91" cy="96.65" r="1"/>
+            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwynedd">
+          <g id="Bangor">
+            <circle cx="50.69" cy="96.65" r="1"/>
+            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Riding of Yorkshire">
+          <g id="Kingston upon Hull">
+            <circle cx="78.4" cy="89.3" r="1"/>
+            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Yorkshire">
+          <g id="Wakefield">
+            <circle cx="70.49" cy="90.99" r="1"/>
+            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Leeds">
+            <circle cx="69.35" cy="89.3" r="1"/>
+            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bradford">
+            <circle cx="67.09" cy="89.3" r="1"/>
+            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lancashire">
+          <g id="Preston">
+            <circle cx="61.43" cy="89.3" r="1"/>
+            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lancaster">
+            <circle cx="61.43" cy="86.47" r="1"/>
+            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="North Yorkshire">
+          <g id="York">
+            <circle cx="72.75" cy="87.6" r="1"/>
+            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ripon">
+            <circle cx="69.92" cy="85.34" r="1"/>
+            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Durham">
+          <g id="Durham">
+            <circle cx="69.35" cy="78.55" r="1"/>
+            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Tyne and Wear">
+          <g id="Sunderland">
+            <circle cx="69.92" cy="76.29" r="1"/>
+            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newcastle upon Tyne">
+            <circle cx="68.79" cy="75.15" r="1"/>
+            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cumbria">
+          <g id="Carlisle">
+            <circle cx="60.3" cy="75.72" r="1"/>
+            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwent (county)">
+          <g id="Newport">
+            <circle cx="58.04" cy="115.88" r="1"/>
+            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Glamorgan">
+          <g id="Cardiff">
+            <circle cx="56.91" cy="117.01" r="1"/>
+            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Glamorgan">
+          <g id="Swansea">
+            <circle cx="52.95" cy="114.75" r="1"/>
+            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Stirling (council area)">
+          <g id="Stirling">
+            <circle cx="51.35" cy="61.00" r="1"/>
+            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Perth and Kinross">
+          <g id="Perth">
+            <circle cx="54.72" cy="58.42" r="1"/>
+            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Highland (council area)">
+          <g id="Inverness">
+            <circle cx="49.39" cy="44.2" r="1"/>
+            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Londonderry">
+          <g id="Derry">
+            <circle cx="27.11" cy="75.92" r="1"/>
+            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh / County Down">
+          <g id="Newry">
+            <circle cx="33.87" cy="86.58" r="1"/>
+            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh">
+          <g id="Armagh">
+            <circle cx="31.45" cy="84.59" r="1"/>
+            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Antrim / County Down">
+          <g id="Belfast">
+            <circle cx="36.41" cy="80.88" r="1"/>
+            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lisburn">
+            <circle cx="34.64" cy="81.71" r="1"/>
+            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -589,257 +683,351 @@
       </g>
     </g>
     <g id="Cities">
-      <g id="Bath">
-        <circle cx="63.13" cy="119.28" r="1"/>
-        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Somerset">
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Truro">
-        <circle cx="42.77" cy="132.85" r="1"/>
-        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cornwall">
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Plymouth">
-        <circle cx="50.12" cy="130.59" r="1"/>
-        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Decon">
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Exeter">
-        <circle cx="54.08" cy="127.2" r="1"/>
-        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Wiltshire">
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wells">
-        <circle cx="60.87" cy="120.41" r="1"/>
-        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Hampshire">
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Salisbury">
-        <circle cx="67.66" cy="122.1" r="1"/>
-        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Sussex">
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Southampton">
-        <circle cx="71.5" cy="125" r="1"/>
-        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="East Sussex">
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Portsmouth">
-        <circle cx="73.5" cy="125.5" r="1"/>
-        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Kent">
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chichester">
-        <circle cx="75.58" cy="124.93" r="1"/>
-        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Greater London">
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Winchester">
-        <circle cx="72.3" cy="122.1" r="1"/>
-        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Oxfordshire">
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Brighton and Hove">
-        <circle cx="80.67" cy="124.93" r="1"/>
-        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Hertfordshire">
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Canterbury">
-        <circle cx="89.94" cy="119.84" r="1"/>
-        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Essex">
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="City of Westminster">
-        <circle cx="79.54" cy="117.01" r="1"/>
-        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gloucestershire">
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Oxford">
-        <circle cx="71.62" cy="113.62" r="1"/>
-        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Dyfed">
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Albans">
-        <circle cx="78.97" cy="113.62" r="1"/>
-        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Herefordshire">
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chelmsford">
-        <circle cx="85.19" cy="113.62" r="1"/>
-        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Worcestershire">
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Newport">
-        <circle cx="58.04" cy="115.88" r="1"/>
-        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cambridgeshire">
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Cardiff">
-        <circle cx="56.91" cy="117.01" r="1"/>
-        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Midlands (county)">
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Swansea">
-        <circle cx="52.95" cy="114.75" r="1"/>
-        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g if="Norfolk">
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Gloucester">
-        <circle cx="64.26" cy="113.05" r="1"/>
-        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Leicestershire">
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Davids">
-        <circle cx="43.67" cy="112.49" r="1"/>
-        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Staffordshire">
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Hereford">
-        <circle cx="61.1" cy="110.79" r="1"/>
-        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Nottinghamshire">
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Worcester">
-        <circle cx="64.83" cy="109.09" r="1"/>
-        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Derbyshire">
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Cambridge">
-        <circle cx="81.23" cy="108.53" r="1"/>
-        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Lincolnshire">
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Ely">
-        <circle cx="81.57" cy="106.27" r="1"/>
-        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="South Yorkshire">
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Coventry">
-        <circle cx="69.35" cy="106.27" r="1"/>
-        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Greater Manchester">
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Birmingham">
-        <circle cx="67.09" cy="105.14" r="1"/>
-        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Merseyside">
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wolverhampton">
-        <circle cx="65.39" cy="104" r="1"/>
-        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cheshire">
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Norwich">
-        <circle cx="89.72" cy="103.44" r="1"/>
-        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Clwyd">
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Peterborough">
-        <circle cx="78.97" cy="104" r="1"/>
-        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gwynedd">
+        <g id="Bangor">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Leicester">
-        <circle cx="72.52" cy="103.44" r="1"/>
-        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="East Riding of Yorkshire">
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Lichfield">
-        <circle cx="67.88" cy="103.44" r="1"/>
-        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Yorkshire">
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Nottingham">
-        <circle cx="72.52" cy="100.04" r="1"/>
-        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Lancashire">
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Derby">
-        <circle cx="69.92" cy="99.48" r="1"/>
-        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="North Yorkshire">
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Stoke-on-Trent">
-        <circle cx="65.39" cy="98.91" r="1"/>
-        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Durham">
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Lincoln">
-        <circle cx="77.27" cy="97.78" r="1"/>
-        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Tyne and Wear">
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Sheffield">
-        <circle cx="69.35" cy="94.39" r="1"/>
-        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cumbria">
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Manchester">
-        <circle cx="64.83" cy="93.26" r="1"/>
-        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gwent (county)">
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Salford">
-        <circle cx="63.92" cy="93.48" r="1"/>
-        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="South Glamorgan">
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Liverpool">
-        <circle cx="59.17" cy="94.39" r="1"/>
-        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Glamorgan">
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chester">
-        <circle cx="60.3" cy="96.65" r="1"/>
-        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Stirling (council area)">
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Asaph">
-        <circle cx="56.91" cy="96.65" r="1"/>
-        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Perth and Kinross">
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Bangor">
-        <circle cx="50.69" cy="96.65" r="1"/>
-        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Highland (council area)">
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Kingston upon Hull">
-        <circle cx="78.4" cy="89.3" r="1"/>
-        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Londonderry">
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wakefield">
-        <circle cx="70.49" cy="90.99" r="1"/>
-        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Armagh / County Down">
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Leeds">
-        <circle cx="69.35" cy="89.3" r="1"/>
-        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Armagh">
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Bradford">
-        <circle cx="67.09" cy="89.3" r="1"/>
-        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Preston">
-        <circle cx="61.43" cy="89.3" r="1"/>
-        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lancaster">
-        <circle cx="61.43" cy="86.47" r="1"/>
-        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="York">
-        <circle cx="72.75" cy="87.6" r="1"/>
-        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Ripon">
-        <circle cx="69.92" cy="85.34" r="1"/>
-        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Durham">
-        <circle cx="69.35" cy="78.55" r="1"/>
-        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Sunderland">
-        <circle cx="69.92" cy="76.29" r="1"/>
-        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newcastle upon Tyne">
-        <circle cx="68.79" cy="75.15" r="1"/>
-        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Carlisle">
-        <circle cx="60.3" cy="75.72" r="1"/>
-        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Stirling">
-        <circle cx="51.35" cy="61.00" r="1"/>
-        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Perth">
-        <circle cx="54.72" cy="58.42" r="1"/>
-        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Inverness">
-        <circle cx="49.39" cy="44.2" r="1"/>
-        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Derry">
-        <circle cx="27.11" cy="75.92" r="1"/>
-        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newry">
-        <circle cx="33.87" cy="86.58" r="1"/>
-        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Armagh">
-        <circle cx="31.45" cy="84.59" r="1"/>
-        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Belfast">
-        <circle cx="36.41" cy="80.88" r="1"/>
-        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lisburn">
-        <circle cx="34.64" cy="81.71" r="1"/>
-        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Antrim / County Down">
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
     </g>
     <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/BoW - Map.html
+++ b/src/note_models/UK_Geog/templates/BoW - Map.html
@@ -250,6 +250,14 @@
             <circle cx="85.19" cy="113.62" r="1"/>
             <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
+          <g id="Colchester">
+            <circle cx="88.03" cy="112.06" r="1"/>
+            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Southend-on-Sea">
+            <circle cx="86.81" cy="116.72" r="1"/>
+            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
         <g id="Gloucestershire">
           <g id="Gloucester">
@@ -344,6 +352,10 @@
           </g>
         </g>
         <g id="South Yorkshire">
+          <g id="Doncaster">
+            <circle cx="72.613" cy="92.65" r="1"/>
+            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
           <g id="Sheffield">
             <circle cx="69.35" cy="94.39" r="1"/>
             <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -375,6 +387,10 @@
           <g id="St Asaph">
             <circle cx="56.91" cy="96.65" r="1"/>
             <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wrexham">
+            <circle cx="59.30" cy="97.79" r="1"/>
+            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="Gwynedd">
@@ -445,6 +461,12 @@
             <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
+        <g id="Buckinghamshire">
+          <g id="Milton Keynes">
+            <circle cx="75.50" cy="110.91" r="1"/>
+            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
         <g id="Gwent (county)">
           <g id="Newport">
             <circle cx="58.04" cy="115.88" r="1"/>
@@ -479,6 +501,18 @@
           <g id="Inverness">
             <circle cx="49.39" cy="44.2" r="1"/>
             <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="Fife">
+          <g id="Dunfermline">
+            <circle cx="55.61" cy="61.85" r="1"/>
+            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="County Down">
+          <g id="Bangor">
+            <circle cx="39.00" cy="79.86" r="1"/>
+            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="County Londonderry">
@@ -770,6 +804,14 @@
           <circle cx="85.19" cy="113.62" r="1"/>
           <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
       <g id="Gloucestershire">
         <g id="Gloucester">
@@ -864,6 +906,10 @@
         </g>
       </g>
       <g id="South Yorkshire">
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
         <g id="Sheffield">
           <circle cx="69.35" cy="94.39" r="1"/>
           <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -895,6 +941,10 @@
         <g id="St Asaph">
           <circle cx="56.91" cy="96.65" r="1"/>
           <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <g id="Gwynedd">
@@ -965,6 +1015,12 @@
           <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
+      <g id="Buckinghamshire">
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
       <g id="Gwent (county)">
         <g id="Newport">
           <circle cx="58.04" cy="115.88" r="1"/>
@@ -999,6 +1055,18 @@
         <g id="Inverness">
           <circle cx="49.39" cy="44.2" r="1"/>
           <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
+      <g id="Fife">
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
+      <g id="County Down">
+        <g id="Bangor">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <g id="County Londonderry">

--- a/src/note_models/UK_Geog/templates/City - County.html
+++ b/src/note_models/UK_Geog/templates/City - County.html
@@ -3,10 +3,19 @@
     [id='Cities'], [id='Bodies of Water']{
       visibility: hidden;
     }
+    .info {
+      max-width: 30em;
+      margin: 0.75em auto;
+      color: #333;
+      font-size: 90%;
+      font-style: italic;
+    }
+
   </style>
     <header>
       <div class="type">City</div>
       <div class="value value--top">{{City}}</div>
+      {{#Info}}<div class="info">Hint: {{Info}}</div>{{/Info}}
 
       <hr>
 
@@ -566,11 +575,19 @@
     transform-box: fill-box;
     transform-origin: center;
   }
+  .info {
+    max-width: 30em;
+    margin: 0.75em auto;
+    color: #333;
+    font-size: 90%;
+    font-style: italic;
+  }
 </style>
 
 <header>
   <div class="type">City</div>
   <div class="value value--top">{{City}}</div>
+  {{#Info}}<div class="info">{{Info}}</div>{{/Info}}
 
   <hr>
 

--- a/src/note_models/UK_Geog/templates/City - County.html
+++ b/src/note_models/UK_Geog/templates/City - County.html
@@ -165,257 +165,351 @@
           </g>
         </g>
         <g id="Cities">
-          <g id="Bath">
-            <circle cx="63.13" cy="119.28" r="1"/>
-            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Somerset">
+            <g id="Bath">
+              <circle cx="63.13" cy="119.28" r="1"/>
+              <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Wells">
+              <circle cx="60.87" cy="120.41" r="1"/>
+              <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Truro">
-            <circle cx="42.77" cy="132.85" r="1"/>
-            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cornwall">
+            <g id="Truro">
+              <circle cx="42.77" cy="132.85" r="1"/>
+              <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Plymouth">
-            <circle cx="50.12" cy="130.59" r="1"/>
-            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Decon">
+            <g id="Plymouth">
+              <circle cx="50.12" cy="130.59" r="1"/>
+              <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Exeter">
+              <circle cx="54.08" cy="127.2" r="1"/>
+              <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Exeter">
-            <circle cx="54.08" cy="127.2" r="1"/>
-            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Wiltshire">
+            <g id="Salisbury">
+              <circle cx="67.66" cy="122.1" r="1"/>
+              <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Wells">
-            <circle cx="60.87" cy="120.41" r="1"/>
-            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Hampshire">
+            <g id="Southampton">
+              <circle cx="71.5" cy="125" r="1"/>
+              <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Portsmouth">
+              <circle cx="73.5" cy="125.5" r="1"/>
+              <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Winchester">
+              <circle cx="72.3" cy="122.1" r="1"/>
+              <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Salisbury">
-            <circle cx="67.66" cy="122.1" r="1"/>
-            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Sussex">
+            <g id="Chichester">
+              <circle cx="75.58" cy="124.93" r="1"/>
+              <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Southampton">
-            <circle cx="71.5" cy="125" r="1"/>
-            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="East Sussex">
+            <g id="Brighton and Hove">
+              <circle cx="80.67" cy="124.93" r="1"/>
+              <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Portsmouth">
-            <circle cx="73.5" cy="125.5" r="1"/>
-            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Kent">
+            <g id="Canterbury">
+              <circle cx="89.94" cy="119.84" r="1"/>
+              <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Chichester">
-            <circle cx="75.58" cy="124.93" r="1"/>
-            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Greater London">
+            <g id="City of Westminster">
+              <circle cx="79.54" cy="117.01" r="1"/>
+              <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Winchester">
-            <circle cx="72.3" cy="122.1" r="1"/>
-            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Oxfordshire">
+            <g id="Oxford">
+              <circle cx="71.62" cy="113.62" r="1"/>
+              <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Brighton and Hove">
-            <circle cx="80.67" cy="124.93" r="1"/>
-            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Hertfordshire">
+            <g id="St Albans">
+              <circle cx="78.97" cy="113.62" r="1"/>
+              <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Canterbury">
-            <circle cx="89.94" cy="119.84" r="1"/>
-            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Essex">
+            <g id="Chelmsford">
+              <circle cx="85.19" cy="113.62" r="1"/>
+              <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="City of Westminster">
-            <circle cx="79.54" cy="117.01" r="1"/>
-            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Gloucestershire">
+            <g id="Gloucester">
+              <circle cx="64.26" cy="113.05" r="1"/>
+              <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Oxford">
-            <circle cx="71.62" cy="113.62" r="1"/>
-            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Dyfed">
+            <g id="St Davids">
+              <circle cx="43.67" cy="112.49" r="1"/>
+              <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="St Albans">
-            <circle cx="78.97" cy="113.62" r="1"/>
-            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Herefordshire">
+            <g id="Hereford">
+              <circle cx="61.1" cy="110.79" r="1"/>
+              <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Chelmsford">
-            <circle cx="85.19" cy="113.62" r="1"/>
-            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Worcestershire">
+            <g id="Worcester">
+              <circle cx="64.83" cy="109.09" r="1"/>
+              <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Newport">
-            <circle cx="58.04" cy="115.88" r="1"/>
-            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cambridgeshire">
+            <g id="Cambridge">
+              <circle cx="81.23" cy="108.53" r="1"/>
+              <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Ely">
+              <circle cx="81.57" cy="106.27" r="1"/>
+              <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Peterborough">
+              <circle cx="78.97" cy="104" r="1"/>
+              <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Cardiff">
-            <circle cx="56.91" cy="117.01" r="1"/>
-            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Midlands (county)">
+            <g id="Coventry">
+              <circle cx="69.35" cy="106.27" r="1"/>
+              <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Birmingham">
+              <circle cx="67.09" cy="105.14" r="1"/>
+              <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Wolverhampton">
+              <circle cx="65.39" cy="104" r="1"/>
+              <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Swansea">
-            <circle cx="52.95" cy="114.75" r="1"/>
-            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g if="Norfolk">
+            <g id="Norwich">
+              <circle cx="89.72" cy="103.44" r="1"/>
+              <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Gloucester">
-            <circle cx="64.26" cy="113.05" r="1"/>
-            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Leicestershire">
+            <g id="Leicester">
+              <circle cx="72.52" cy="103.44" r="1"/>
+              <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="St Davids">
-            <circle cx="43.67" cy="112.49" r="1"/>
-            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Staffordshire">
+            <g id="Lichfield">
+              <circle cx="67.88" cy="103.44" r="1"/>
+              <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Stoke-on-Trent">
+              <circle cx="65.39" cy="98.91" r="1"/>
+              <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Hereford">
-            <circle cx="61.1" cy="110.79" r="1"/>
-            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Nottinghamshire">
+            <g id="Nottingham">
+              <circle cx="72.52" cy="100.04" r="1"/>
+              <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Worcester">
-            <circle cx="64.83" cy="109.09" r="1"/>
-            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Derbyshire">
+            <g id="Derby">
+              <circle cx="69.92" cy="99.48" r="1"/>
+              <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Cambridge">
-            <circle cx="81.23" cy="108.53" r="1"/>
-            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Lincolnshire">
+            <g id="Lincoln">
+              <circle cx="77.27" cy="97.78" r="1"/>
+              <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Ely">
-            <circle cx="81.57" cy="106.27" r="1"/>
-            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="South Yorkshire">
+            <g id="Sheffield">
+              <circle cx="69.35" cy="94.39" r="1"/>
+              <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Coventry">
-            <circle cx="69.35" cy="106.27" r="1"/>
-            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Greater Manchester">
+            <g id="Manchester">
+              <circle cx="64.83" cy="93.26" r="1"/>
+              <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Salford">
+              <circle cx="63.92" cy="93.48" r="1"/>
+              <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Birmingham">
-            <circle cx="67.09" cy="105.14" r="1"/>
-            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Merseyside">
+            <g id="Liverpool">
+              <circle cx="59.17" cy="94.39" r="1"/>
+              <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Wolverhampton">
-            <circle cx="65.39" cy="104" r="1"/>
-            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cheshire">
+            <g id="Chester">
+              <circle cx="60.3" cy="96.65" r="1"/>
+              <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Norwich">
-            <circle cx="89.72" cy="103.44" r="1"/>
-            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Clwyd">
+            <g id="St Asaph">
+              <circle cx="56.91" cy="96.65" r="1"/>
+              <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Peterborough">
-            <circle cx="78.97" cy="104" r="1"/>
-            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Gwynedd">
+            <g id="Bangor">
+              <circle cx="50.69" cy="96.65" r="1"/>
+              <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Leicester">
-            <circle cx="72.52" cy="103.44" r="1"/>
-            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="East Riding of Yorkshire">
+            <g id="Kingston upon Hull">
+              <circle cx="78.4" cy="89.3" r="1"/>
+              <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Lichfield">
-            <circle cx="67.88" cy="103.44" r="1"/>
-            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Yorkshire">
+            <g id="Wakefield">
+              <circle cx="70.49" cy="90.99" r="1"/>
+              <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Leeds">
+              <circle cx="69.35" cy="89.3" r="1"/>
+              <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Bradford">
+              <circle cx="67.09" cy="89.3" r="1"/>
+              <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Nottingham">
-            <circle cx="72.52" cy="100.04" r="1"/>
-            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Lancashire">
+            <g id="Preston">
+              <circle cx="61.43" cy="89.3" r="1"/>
+              <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Lancaster">
+              <circle cx="61.43" cy="86.47" r="1"/>
+              <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Derby">
-            <circle cx="69.92" cy="99.48" r="1"/>
-            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="North Yorkshire">
+            <g id="York">
+              <circle cx="72.75" cy="87.6" r="1"/>
+              <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Ripon">
+              <circle cx="69.92" cy="85.34" r="1"/>
+              <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Stoke-on-Trent">
-            <circle cx="65.39" cy="98.91" r="1"/>
-            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Durham">
+            <g id="Durham">
+              <circle cx="69.35" cy="78.55" r="1"/>
+              <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Lincoln">
-            <circle cx="77.27" cy="97.78" r="1"/>
-            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Tyne and Wear">
+            <g id="Sunderland">
+              <circle cx="69.92" cy="76.29" r="1"/>
+              <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Newcastle upon Tyne">
+              <circle cx="68.79" cy="75.15" r="1"/>
+              <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Sheffield">
-            <circle cx="69.35" cy="94.39" r="1"/>
-            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cumbria">
+            <g id="Carlisle">
+              <circle cx="60.3" cy="75.72" r="1"/>
+              <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Manchester">
-            <circle cx="64.83" cy="93.26" r="1"/>
-            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Gwent (county)">
+            <g id="Newport">
+              <circle cx="58.04" cy="115.88" r="1"/>
+              <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Salford">
-            <circle cx="63.92" cy="93.48" r="1"/>
-            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="South Glamorgan">
+            <g id="Cardiff">
+              <circle cx="56.91" cy="117.01" r="1"/>
+              <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Liverpool">
-            <circle cx="59.17" cy="94.39" r="1"/>
-            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Glamorgan">
+            <g id="Swansea">
+              <circle cx="52.95" cy="114.75" r="1"/>
+              <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Chester">
-            <circle cx="60.3" cy="96.65" r="1"/>
-            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Stirling (council area)">
+            <g id="Stirling">
+              <circle cx="51.35" cy="61.00" r="1"/>
+              <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="St Asaph">
-            <circle cx="56.91" cy="96.65" r="1"/>
-            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Perth and Kinross">
+            <g id="Perth">
+              <circle cx="54.72" cy="58.42" r="1"/>
+              <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Bangor">
-            <circle cx="50.69" cy="96.65" r="1"/>
-            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Highland (council area)">
+            <g id="Inverness">
+              <circle cx="49.39" cy="44.2" r="1"/>
+              <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Kingston upon Hull">
-            <circle cx="78.4" cy="89.3" r="1"/>
-            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Londonderry">
+            <g id="Derry">
+              <circle cx="27.11" cy="75.92" r="1"/>
+              <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Wakefield">
-            <circle cx="70.49" cy="90.99" r="1"/>
-            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Armagh / County Down">
+            <g id="Newry">
+              <circle cx="33.87" cy="86.58" r="1"/>
+              <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Leeds">
-            <circle cx="69.35" cy="89.3" r="1"/>
-            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Armagh">
+            <g id="Armagh">
+              <circle cx="31.45" cy="84.59" r="1"/>
+              <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Bradford">
-            <circle cx="67.09" cy="89.3" r="1"/>
-            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Preston">
-            <circle cx="61.43" cy="89.3" r="1"/>
-            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lancaster">
-            <circle cx="61.43" cy="86.47" r="1"/>
-            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="York">
-            <circle cx="72.75" cy="87.6" r="1"/>
-            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ripon">
-            <circle cx="69.92" cy="85.34" r="1"/>
-            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Durham">
-            <circle cx="69.35" cy="78.55" r="1"/>
-            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Sunderland">
-            <circle cx="69.92" cy="76.29" r="1"/>
-            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newcastle upon Tyne">
-            <circle cx="68.79" cy="75.15" r="1"/>
-            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Carlisle">
-            <circle cx="60.3" cy="75.72" r="1"/>
-            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Stirling">
-            <circle cx="51.35" cy="61.00" r="1"/>
-            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Perth">
-            <circle cx="54.72" cy="58.42" r="1"/>
-            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Inverness">
-            <circle cx="49.39" cy="44.2" r="1"/>
-            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Derry">
-            <circle cx="27.11" cy="75.92" r="1"/>
-            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newry">
-            <circle cx="33.87" cy="86.58" r="1"/>
-            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Armagh">
-            <circle cx="31.45" cy="84.59" r="1"/>
-            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Belfast">
-            <circle cx="36.41" cy="80.88" r="1"/>
-            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lisburn">
-            <circle cx="34.64" cy="81.71" r="1"/>
-            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Antrim / County Down">
+            <g id="Belfast">
+              <circle cx="36.41" cy="80.88" r="1"/>
+              <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Lisburn">
+              <circle cx="34.64" cy="81.71" r="1"/>
+              <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
         </g>
         <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -427,7 +521,9 @@
 --
 
 <style>
-  [id='Cities'] > :not([id='{{City}}']), [id='Bodies of Water'] {
+  [id='Cities'] > :not([id='{{MacroLocation}}']),
+  [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
+  [id='Bodies of Water'] {
     visibility: hidden;
   }
   [id='Regions'] > * > [id='{{City}}']{
@@ -599,261 +695,356 @@
       </g>
     </g>
     <g id="Cities">
-      <g id="Bath">
-        <circle cx="63.13" cy="119.28" r="1"/>
-        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Somerset">
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Truro">
-        <circle cx="42.77" cy="132.85" r="1"/>
-        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cornwall">
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Plymouth">
-        <circle cx="50.12" cy="130.59" r="1"/>
-        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Decon">
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Exeter">
-        <circle cx="54.08" cy="127.2" r="1"/>
-        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Wiltshire">
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wells">
-        <circle cx="60.87" cy="120.41" r="1"/>
-        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Hampshire">
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Salisbury">
-        <circle cx="67.66" cy="122.1" r="1"/>
-        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Sussex">
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Southampton">
-        <circle cx="71.5" cy="125" r="1"/>
-        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="East Sussex">
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Portsmouth">
-        <circle cx="73.5" cy="125.5" r="1"/>
-        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Kent">
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chichester">
-        <circle cx="75.58" cy="124.93" r="1"/>
-        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Greater London">
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Winchester">
-        <circle cx="72.3" cy="122.1" r="1"/>
-        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Oxfordshire">
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Brighton and Hove">
-        <circle cx="80.67" cy="124.93" r="1"/>
-        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Hertfordshire">
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Canterbury">
-        <circle cx="89.94" cy="119.84" r="1"/>
-        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Essex">
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="City of Westminster">
-        <circle cx="79.54" cy="117.01" r="1"/>
-        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gloucestershire">
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Oxford">
-        <circle cx="71.62" cy="113.62" r="1"/>
-        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Dyfed">
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Albans">
-        <circle cx="78.97" cy="113.62" r="1"/>
-        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Herefordshire">
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chelmsford">
-        <circle cx="85.19" cy="113.62" r="1"/>
-        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Worcestershire">
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Newport">
-        <circle cx="58.04" cy="115.88" r="1"/>
-        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cambridgeshire">
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Cardiff">
-        <circle cx="56.91" cy="117.01" r="1"/>
-        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Midlands (county)">
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Swansea">
-        <circle cx="52.95" cy="114.75" r="1"/>
-        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g if="Norfolk">
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Gloucester">
-        <circle cx="64.26" cy="113.05" r="1"/>
-        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Leicestershire">
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Davids">
-        <circle cx="43.67" cy="112.49" r="1"/>
-        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Staffordshire">
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Hereford">
-        <circle cx="61.1" cy="110.79" r="1"/>
-        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Nottinghamshire">
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Worcester">
-        <circle cx="64.83" cy="109.09" r="1"/>
-        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Derbyshire">
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Cambridge">
-        <circle cx="81.23" cy="108.53" r="1"/>
-        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Lincolnshire">
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Ely">
-        <circle cx="81.57" cy="106.27" r="1"/>
-        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="South Yorkshire">
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Coventry">
-        <circle cx="69.35" cy="106.27" r="1"/>
-        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Greater Manchester">
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Birmingham">
-        <circle cx="67.09" cy="105.14" r="1"/>
-        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Merseyside">
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wolverhampton">
-        <circle cx="65.39" cy="104" r="1"/>
-        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cheshire">
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Norwich">
-        <circle cx="89.72" cy="103.44" r="1"/>
-        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Clwyd">
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Peterborough">
-        <circle cx="78.97" cy="104" r="1"/>
-        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gwynedd">
+        <g id="Bangor">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Leicester">
-        <circle cx="72.52" cy="103.44" r="1"/>
-        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="East Riding of Yorkshire">
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Lichfield">
-        <circle cx="67.88" cy="103.44" r="1"/>
-        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Yorkshire">
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Nottingham">
-        <circle cx="72.52" cy="100.04" r="1"/>
-        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Lancashire">
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Derby">
-        <circle cx="69.92" cy="99.48" r="1"/>
-        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="North Yorkshire">
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Stoke-on-Trent">
-        <circle cx="65.39" cy="98.91" r="1"/>
-        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Durham">
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Lincoln">
-        <circle cx="77.27" cy="97.78" r="1"/>
-        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Tyne and Wear">
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Sheffield">
-        <circle cx="69.35" cy="94.39" r="1"/>
-        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cumbria">
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Manchester">
-        <circle cx="64.83" cy="93.26" r="1"/>
-        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gwent (county)">
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Salford">
-        <circle cx="63.92" cy="93.48" r="1"/>
-        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="South Glamorgan">
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Liverpool">
-        <circle cx="59.17" cy="94.39" r="1"/>
-        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Glamorgan">
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chester">
-        <circle cx="60.3" cy="96.65" r="1"/>
-        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Stirling (council area)">
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Asaph">
-        <circle cx="56.91" cy="96.65" r="1"/>
-        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Perth and Kinross">
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Bangor">
-        <circle cx="50.69" cy="96.65" r="1"/>
-        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Highland (council area)">
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Kingston upon Hull">
-        <circle cx="78.4" cy="89.3" r="1"/>
-        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Londonderry">
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wakefield">
-        <circle cx="70.49" cy="90.99" r="1"/>
-        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Armagh / County Down">
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Leeds">
-        <circle cx="69.35" cy="89.3" r="1"/>
-        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Armagh">
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Bradford">
-        <circle cx="67.09" cy="89.3" r="1"/>
-        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Preston">
-        <circle cx="61.43" cy="89.3" r="1"/>
-        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lancaster">
-        <circle cx="61.43" cy="86.47" r="1"/>
-        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="York">
-        <circle cx="72.75" cy="87.6" r="1"/>
-        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Ripon">
-        <circle cx="69.92" cy="85.34" r="1"/>
-        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Durham">
-        <circle cx="69.35" cy="78.55" r="1"/>
-        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Sunderland">
-        <circle cx="69.92" cy="76.29" r="1"/>
-        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newcastle upon Tyne">
-        <circle cx="68.79" cy="75.15" r="1"/>
-        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Carlisle">
-        <circle cx="60.3" cy="75.72" r="1"/>
-        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Stirling">
-        <circle cx="51.35" cy="61.00" r="1"/>
-        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Perth">
-        <circle cx="54.72" cy="58.42" r="1"/>
-        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Inverness">
-        <circle cx="49.39" cy="44.2" r="1"/>
-        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Derry">
-        <circle cx="27.11" cy="75.92" r="1"/>
-        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newry">
-        <circle cx="33.87" cy="86.58" r="1"/>
-        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Armagh">
-        <circle cx="31.45" cy="84.59" r="1"/>
-        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Belfast">
-        <circle cx="36.41" cy="80.88" r="1"/>
-        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lisburn">
-        <circle cx="34.64" cy="81.71" r="1"/>
-        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Antrim / County Down">
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
     </g>
     <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
   </svg>
+
 
 </div>
 <script>

--- a/src/note_models/UK_Geog/templates/City - County.html
+++ b/src/note_models/UK_Geog/templates/City - County.html
@@ -252,6 +252,14 @@
               <circle cx="85.19" cy="113.62" r="1"/>
               <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
+            <g id="Colchester">
+              <circle cx="88.03" cy="112.06" r="1"/>
+              <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Southend-on-Sea">
+              <circle cx="86.81" cy="116.72" r="1"/>
+              <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
           <g id="Gloucestershire">
             <g id="Gloucester">
@@ -346,6 +354,10 @@
             </g>
           </g>
           <g id="South Yorkshire">
+            <g id="Doncaster">
+              <circle cx="72.613" cy="92.65" r="1"/>
+              <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
             <g id="Sheffield">
               <circle cx="69.35" cy="94.39" r="1"/>
               <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -377,6 +389,10 @@
             <g id="St Asaph">
               <circle cx="56.91" cy="96.65" r="1"/>
               <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Wrexham">
+              <circle cx="59.30" cy="97.79" r="1"/>
+              <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
           </g>
           <g id="Gwynedd">
@@ -447,6 +463,12 @@
               <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
           </g>
+          <g id="Buckinghamshire">
+            <g id="Milton Keynes">
+              <circle cx="75.50" cy="110.91" r="1"/>
+              <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+          </g>
           <g id="Gwent (county)">
             <g id="Newport">
               <circle cx="58.04" cy="115.88" r="1"/>
@@ -481,6 +503,18 @@
             <g id="Inverness">
               <circle cx="49.39" cy="44.2" r="1"/>
               <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+          </g>
+          <g id="Fife">
+            <g id="Dunfermline">
+              <circle cx="55.61" cy="61.85" r="1"/>
+              <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+          </g>
+          <g id="County Down">
+            <g id="Bangor">
+              <circle cx="39.00" cy="79.86" r="1"/>
+              <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
           </g>
           <g id="County Londonderry">
@@ -782,6 +816,14 @@
           <circle cx="85.19" cy="113.62" r="1"/>
           <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
       <g id="Gloucestershire">
         <g id="Gloucester">
@@ -876,6 +918,10 @@
         </g>
       </g>
       <g id="South Yorkshire">
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
         <g id="Sheffield">
           <circle cx="69.35" cy="94.39" r="1"/>
           <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -907,6 +953,10 @@
         <g id="St Asaph">
           <circle cx="56.91" cy="96.65" r="1"/>
           <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <g id="Gwynedd">
@@ -977,6 +1027,12 @@
           <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
+      <g id="Buckinghamshire">
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
       <g id="Gwent (county)">
         <g id="Newport">
           <circle cx="58.04" cy="115.88" r="1"/>
@@ -1011,6 +1067,18 @@
         <g id="Inverness">
           <circle cx="49.39" cy="44.2" r="1"/>
           <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
+      <g id="Fife">
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
+      <g id="County Down">
+        <g id="Bangor">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <g id="County Londonderry">

--- a/src/note_models/UK_Geog/templates/City - County.html
+++ b/src/note_models/UK_Geog/templates/City - County.html
@@ -174,385 +174,285 @@
           </g>
         </g>
         <g id="Cities">
-          <g id="Somerset">
-            <g id="Bath">
-              <circle cx="63.13" cy="119.28" r="1"/>
-              <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Wells">
-              <circle cx="60.87" cy="120.41" r="1"/>
-              <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Bath">
+            <circle cx="63.13" cy="119.28" r="1"/>
+            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cornwall">
-            <g id="Truro">
-              <circle cx="42.77" cy="132.85" r="1"/>
-              <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Truro">
+            <circle cx="42.77" cy="132.85" r="1"/>
+            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Decon">
-            <g id="Plymouth">
-              <circle cx="50.12" cy="130.59" r="1"/>
-              <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Exeter">
-              <circle cx="54.08" cy="127.2" r="1"/>
-              <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Plymouth">
+            <circle cx="50.12" cy="130.59" r="1"/>
+            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Wiltshire">
-            <g id="Salisbury">
-              <circle cx="67.66" cy="122.1" r="1"/>
-              <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Exeter">
+            <circle cx="54.08" cy="127.2" r="1"/>
+            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Hampshire">
-            <g id="Southampton">
-              <circle cx="71.5" cy="125" r="1"/>
-              <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Portsmouth">
-              <circle cx="73.5" cy="125.5" r="1"/>
-              <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Winchester">
-              <circle cx="72.3" cy="122.1" r="1"/>
-              <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wells">
+            <circle cx="60.87" cy="120.41" r="1"/>
+            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Sussex">
-            <g id="Chichester">
-              <circle cx="75.58" cy="124.93" r="1"/>
-              <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Salisbury">
+            <circle cx="67.66" cy="122.1" r="1"/>
+            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="East Sussex">
-            <g id="Brighton and Hove">
-              <circle cx="80.67" cy="124.93" r="1"/>
-              <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Southampton">
+            <circle cx="71.5" cy="125" r="1"/>
+            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Kent">
-            <g id="Canterbury">
-              <circle cx="89.94" cy="119.84" r="1"/>
-              <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Portsmouth">
+            <circle cx="73.5" cy="125.5" r="1"/>
+            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Greater London">
-            <g id="City of Westminster">
-              <circle cx="79.54" cy="117.01" r="1"/>
-              <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Chichester">
+            <circle cx="75.58" cy="124.93" r="1"/>
+            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Oxfordshire">
-            <g id="Oxford">
-              <circle cx="71.62" cy="113.62" r="1"/>
-              <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Winchester">
+            <circle cx="72.3" cy="122.1" r="1"/>
+            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Hertfordshire">
-            <g id="St Albans">
-              <circle cx="78.97" cy="113.62" r="1"/>
-              <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Brighton and Hove">
+            <circle cx="80.67" cy="124.93" r="1"/>
+            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Essex">
-            <g id="Chelmsford">
-              <circle cx="85.19" cy="113.62" r="1"/>
-              <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Colchester">
-              <circle cx="88.03" cy="112.06" r="1"/>
-              <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Southend-on-Sea">
-              <circle cx="86.81" cy="116.72" r="1"/>
-              <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Canterbury">
+            <circle cx="89.94" cy="119.84" r="1"/>
+            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Gloucestershire">
-            <g id="Gloucester">
-              <circle cx="64.26" cy="113.05" r="1"/>
-              <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="City of Westminster">
+            <circle cx="79.54" cy="117.01" r="1"/>
+            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Dyfed">
-            <g id="St Davids">
-              <circle cx="43.67" cy="112.49" r="1"/>
-              <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Southend-on-Sea">
+            <circle cx="86.81" cy="116.72" r="1"/>
+            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Herefordshire">
-            <g id="Hereford">
-              <circle cx="61.1" cy="110.79" r="1"/>
-              <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Oxford">
+            <circle cx="71.62" cy="113.62" r="1"/>
+            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Worcestershire">
-            <g id="Worcester">
-              <circle cx="64.83" cy="109.09" r="1"/>
-              <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="St Albans">
+            <circle cx="78.97" cy="113.62" r="1"/>
+            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cambridgeshire">
-            <g id="Cambridge">
-              <circle cx="81.23" cy="108.53" r="1"/>
-              <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Ely">
-              <circle cx="81.57" cy="106.27" r="1"/>
-              <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Peterborough">
-              <circle cx="78.97" cy="104" r="1"/>
-              <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Chelmsford">
+            <circle cx="85.19" cy="113.62" r="1"/>
+            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Midlands (county)">
-            <g id="Coventry">
-              <circle cx="69.35" cy="106.27" r="1"/>
-              <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Birmingham">
-              <circle cx="67.09" cy="105.14" r="1"/>
-              <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Wolverhampton">
-              <circle cx="65.39" cy="104" r="1"/>
-              <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Newport">
+            <circle cx="58.04" cy="115.88" r="1"/>
+            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g if="Norfolk">
-            <g id="Norwich">
-              <circle cx="89.72" cy="103.44" r="1"/>
-              <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Cardiff">
+            <circle cx="56.91" cy="117.01" r="1"/>
+            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Leicestershire">
-            <g id="Leicester">
-              <circle cx="72.52" cy="103.44" r="1"/>
-              <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Swansea">
+            <circle cx="52.95" cy="114.75" r="1"/>
+            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Staffordshire">
-            <g id="Lichfield">
-              <circle cx="67.88" cy="103.44" r="1"/>
-              <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Stoke-on-Trent">
-              <circle cx="65.39" cy="98.91" r="1"/>
-              <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Gloucester">
+            <circle cx="64.26" cy="113.05" r="1"/>
+            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Nottinghamshire">
-            <g id="Nottingham">
-              <circle cx="72.52" cy="100.04" r="1"/>
-              <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Colchester">
+            <circle cx="88.03" cy="112.06" r="1"/>
+            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Derbyshire">
-            <g id="Derby">
-              <circle cx="69.92" cy="99.48" r="1"/>
-              <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="St Davids">
+            <circle cx="43.67" cy="112.49" r="1"/>
+            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Lincolnshire">
-            <g id="Lincoln">
-              <circle cx="77.27" cy="97.78" r="1"/>
-              <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Milton Keynes">
+            <circle cx="75.50" cy="110.91" r="1"/>
+            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="South Yorkshire">
-            <g id="Doncaster">
-              <circle cx="72.613" cy="92.65" r="1"/>
-              <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Sheffield">
-              <circle cx="69.35" cy="94.39" r="1"/>
-              <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Hereford">
+            <circle cx="61.1" cy="110.79" r="1"/>
+            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Greater Manchester">
-            <g id="Manchester">
-              <circle cx="64.83" cy="93.26" r="1"/>
-              <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Salford">
-              <circle cx="63.92" cy="93.48" r="1"/>
-              <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Worcester">
+            <circle cx="64.83" cy="109.09" r="1"/>
+            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Merseyside">
-            <g id="Liverpool">
-              <circle cx="59.17" cy="94.39" r="1"/>
-              <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Cambridge">
+            <circle cx="81.23" cy="108.53" r="1"/>
+            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cheshire">
-            <g id="Chester">
-              <circle cx="60.3" cy="96.65" r="1"/>
-              <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Ely">
+            <circle cx="81.57" cy="106.27" r="1"/>
+            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Clwyd">
-            <g id="St Asaph">
-              <circle cx="56.91" cy="96.65" r="1"/>
-              <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Wrexham">
-              <circle cx="59.30" cy="97.79" r="1"/>
-              <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Coventry">
+            <circle cx="69.35" cy="106.27" r="1"/>
+            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Gwynedd">
-            <g id="Bangor">
-              <circle cx="50.69" cy="96.65" r="1"/>
-              <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Birmingham">
+            <circle cx="67.09" cy="105.14" r="1"/>
+            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="East Riding of Yorkshire">
-            <g id="Kingston upon Hull">
-              <circle cx="78.4" cy="89.3" r="1"/>
-              <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wolverhampton">
+            <circle cx="65.39" cy="104" r="1"/>
+            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Yorkshire">
-            <g id="Wakefield">
-              <circle cx="70.49" cy="90.99" r="1"/>
-              <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Leeds">
-              <circle cx="69.35" cy="89.3" r="1"/>
-              <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Bradford">
-              <circle cx="67.09" cy="89.3" r="1"/>
-              <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Norwich">
+            <circle cx="89.72" cy="103.44" r="1"/>
+            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Lancashire">
-            <g id="Preston">
-              <circle cx="61.43" cy="89.3" r="1"/>
-              <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Lancaster">
-              <circle cx="61.43" cy="86.47" r="1"/>
-              <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Peterborough">
+            <circle cx="78.97" cy="104" r="1"/>
+            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="North Yorkshire">
-            <g id="York">
-              <circle cx="72.75" cy="87.6" r="1"/>
-              <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Ripon">
-              <circle cx="69.92" cy="85.34" r="1"/>
-              <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Leicester">
+            <circle cx="72.52" cy="103.44" r="1"/>
+            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Durham">
-            <g id="Durham">
-              <circle cx="69.35" cy="78.55" r="1"/>
-              <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Lichfield">
+            <circle cx="67.88" cy="103.44" r="1"/>
+            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Tyne and Wear">
-            <g id="Sunderland">
-              <circle cx="69.92" cy="76.29" r="1"/>
-              <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Newcastle upon Tyne">
-              <circle cx="68.79" cy="75.15" r="1"/>
-              <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Nottingham">
+            <circle cx="72.52" cy="100.04" r="1"/>
+            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cumbria">
-            <g id="Carlisle">
-              <circle cx="60.3" cy="75.72" r="1"/>
-              <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Derby">
+            <circle cx="69.92" cy="99.48" r="1"/>
+            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Buckinghamshire">
-            <g id="Milton Keynes">
-              <circle cx="75.50" cy="110.91" r="1"/>
-              <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Stoke-on-Trent">
+            <circle cx="65.39" cy="98.91" r="1"/>
+            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Gwent (county)">
-            <g id="Newport">
-              <circle cx="58.04" cy="115.88" r="1"/>
-              <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Lincoln">
+            <circle cx="77.27" cy="97.78" r="1"/>
+            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="South Glamorgan">
-            <g id="Cardiff">
-              <circle cx="56.91" cy="117.01" r="1"/>
-              <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Sheffield">
+            <circle cx="69.35" cy="94.39" r="1"/>
+            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Glamorgan">
-            <g id="Swansea">
-              <circle cx="52.95" cy="114.75" r="1"/>
-              <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Doncaster">
+            <circle cx="72.613" cy="92.65" r="1"/>
+            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Stirling (council area)">
-            <g id="Stirling">
-              <circle cx="51.35" cy="61.00" r="1"/>
-              <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Manchester">
+            <circle cx="64.83" cy="93.26" r="1"/>
+            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Perth and Kinross">
-            <g id="Perth">
-              <circle cx="54.72" cy="58.42" r="1"/>
-              <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Salford">
+            <circle cx="63.92" cy="93.48" r="1"/>
+            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Highland (council area)">
-            <g id="Inverness">
-              <circle cx="49.39" cy="44.2" r="1"/>
-              <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Liverpool">
+            <circle cx="59.17" cy="94.39" r="1"/>
+            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Fife">
-            <g id="Dunfermline">
-              <circle cx="55.61" cy="61.85" r="1"/>
-              <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Chester">
+            <circle cx="60.3" cy="96.65" r="1"/>
+            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Down">
-            <g id="Bangor">
-              <circle cx="39.00" cy="79.86" r="1"/>
-              <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="St Asaph">
+            <circle cx="56.91" cy="96.65" r="1"/>
+            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Londonderry">
-            <g id="Derry">
-              <circle cx="27.11" cy="75.92" r="1"/>
-              <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wrexham">
+            <circle cx="59.30" cy="97.79" r="1"/>
+            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Armagh / County Down">
-            <g id="Newry">
-              <circle cx="33.87" cy="86.58" r="1"/>
-              <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Bangor, Gwynedd">
+            <circle cx="50.69" cy="96.65" r="1"/>
+            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Armagh">
-            <g id="Armagh">
-              <circle cx="31.45" cy="84.59" r="1"/>
-              <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Kingston upon Hull">
+            <circle cx="78.4" cy="89.3" r="1"/>
+            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Antrim / County Down">
-            <g id="Belfast">
-              <circle cx="36.41" cy="80.88" r="1"/>
-              <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Lisburn">
-              <circle cx="34.64" cy="81.71" r="1"/>
-              <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wakefield">
+            <circle cx="70.49" cy="90.99" r="1"/>
+            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Leeds">
+            <circle cx="69.35" cy="89.3" r="1"/>
+            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bradford">
+            <circle cx="67.09" cy="89.3" r="1"/>
+            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Preston">
+            <circle cx="61.43" cy="89.3" r="1"/>
+            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lancaster">
+            <circle cx="61.43" cy="86.47" r="1"/>
+            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="York">
+            <circle cx="72.75" cy="87.6" r="1"/>
+            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ripon">
+            <circle cx="69.92" cy="85.34" r="1"/>
+            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Durham">
+            <circle cx="69.35" cy="78.55" r="1"/>
+            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Sunderland">
+            <circle cx="69.92" cy="76.29" r="1"/>
+            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newcastle upon Tyne">
+            <circle cx="68.79" cy="75.15" r="1"/>
+            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Carlisle">
+            <circle cx="60.3" cy="75.72" r="1"/>
+            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Dunfermline">
+            <circle cx="55.61" cy="61.85" r="1"/>
+            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Stirling">
+            <circle cx="51.35" cy="61.00" r="1"/>
+            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Perth">
+            <circle cx="54.72" cy="58.42" r="1"/>
+            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Inverness">
+            <circle cx="49.39" cy="44.2" r="1"/>
+            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Derry">
+            <circle cx="27.11" cy="75.92" r="1"/>
+            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newry">
+            <circle cx="33.87" cy="86.58" r="1"/>
+            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bangor, County Down">
+            <circle cx="39.00" cy="79.86" r="1"/>
+            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Armagh">
+            <circle cx="31.45" cy="84.59" r="1"/>
+            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Belfast">
+            <circle cx="36.41" cy="80.88" r="1"/>
+            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lisburn">
+            <circle cx="34.64" cy="81.71" r="1"/>
+            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -564,12 +464,10 @@
 --
 
 <style>
-  [id='Cities'] > :not([id='{{MacroLocation}}']),
-  [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
-  [id='Bodies of Water'] {
+  [id='Cities'] > :not([id='{{Location}}']), [id='Bodies of Water'] {
     visibility: hidden;
   }
-  [id='Regions'] > * > [id='{{City}}']{
+  [id='Regions'] > * > [id='{{Location}}']{
     animation: jump 0.75s;
     animation-iteration-count: infinite;
     transform-box: fill-box;
@@ -746,385 +644,285 @@
       </g>
     </g>
     <g id="Cities">
-      <g id="Somerset">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Bath">
+        <circle cx="63.13" cy="119.28" r="1"/>
+        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cornwall">
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Truro">
+        <circle cx="42.77" cy="132.85" r="1"/>
+        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Decon">
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Plymouth">
+        <circle cx="50.12" cy="130.59" r="1"/>
+        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Wiltshire">
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Exeter">
+        <circle cx="54.08" cy="127.2" r="1"/>
+        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Hampshire">
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wells">
+        <circle cx="60.87" cy="120.41" r="1"/>
+        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Sussex">
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Salisbury">
+        <circle cx="67.66" cy="122.1" r="1"/>
+        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="East Sussex">
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Southampton">
+        <circle cx="71.5" cy="125" r="1"/>
+        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Kent">
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Portsmouth">
+        <circle cx="73.5" cy="125.5" r="1"/>
+        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Greater London">
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chichester">
+        <circle cx="75.58" cy="124.93" r="1"/>
+        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Oxfordshire">
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Winchester">
+        <circle cx="72.3" cy="122.1" r="1"/>
+        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Hertfordshire">
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Brighton and Hove">
+        <circle cx="80.67" cy="124.93" r="1"/>
+        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Essex">
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Colchester">
-          <circle cx="88.03" cy="112.06" r="1"/>
-          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Southend-on-Sea">
-          <circle cx="86.81" cy="116.72" r="1"/>
-          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Canterbury">
+        <circle cx="89.94" cy="119.84" r="1"/>
+        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gloucestershire">
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="City of Westminster">
+        <circle cx="79.54" cy="117.01" r="1"/>
+        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Dyfed">
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Southend-on-Sea">
+        <circle cx="86.81" cy="116.72" r="1"/>
+        <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Herefordshire">
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Oxford">
+        <circle cx="71.62" cy="113.62" r="1"/>
+        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Worcestershire">
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Albans">
+        <circle cx="78.97" cy="113.62" r="1"/>
+        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cambridgeshire">
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chelmsford">
+        <circle cx="85.19" cy="113.62" r="1"/>
+        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Midlands (county)">
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Newport">
+        <circle cx="58.04" cy="115.88" r="1"/>
+        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g if="Norfolk">
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Cardiff">
+        <circle cx="56.91" cy="117.01" r="1"/>
+        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Leicestershire">
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Swansea">
+        <circle cx="52.95" cy="114.75" r="1"/>
+        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Staffordshire">
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Gloucester">
+        <circle cx="64.26" cy="113.05" r="1"/>
+        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Nottinghamshire">
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Colchester">
+        <circle cx="88.03" cy="112.06" r="1"/>
+        <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Derbyshire">
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Davids">
+        <circle cx="43.67" cy="112.49" r="1"/>
+        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Lincolnshire">
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Milton Keynes">
+        <circle cx="75.50" cy="110.91" r="1"/>
+        <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="South Yorkshire">
-        <g id="Doncaster">
-          <circle cx="72.613" cy="92.65" r="1"/>
-          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Hereford">
+        <circle cx="61.1" cy="110.79" r="1"/>
+        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Greater Manchester">
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Worcester">
+        <circle cx="64.83" cy="109.09" r="1"/>
+        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Merseyside">
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Cambridge">
+        <circle cx="81.23" cy="108.53" r="1"/>
+        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cheshire">
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Ely">
+        <circle cx="81.57" cy="106.27" r="1"/>
+        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Clwyd">
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wrexham">
-          <circle cx="59.30" cy="97.79" r="1"/>
-          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Coventry">
+        <circle cx="69.35" cy="106.27" r="1"/>
+        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gwynedd">
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Birmingham">
+        <circle cx="67.09" cy="105.14" r="1"/>
+        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="East Riding of Yorkshire">
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wolverhampton">
+        <circle cx="65.39" cy="104" r="1"/>
+        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Yorkshire">
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Norwich">
+        <circle cx="89.72" cy="103.44" r="1"/>
+        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Lancashire">
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Peterborough">
+        <circle cx="78.97" cy="104" r="1"/>
+        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="North Yorkshire">
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Leicester">
+        <circle cx="72.52" cy="103.44" r="1"/>
+        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Durham">
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Lichfield">
+        <circle cx="67.88" cy="103.44" r="1"/>
+        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Tyne and Wear">
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Nottingham">
+        <circle cx="72.52" cy="100.04" r="1"/>
+        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cumbria">
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Derby">
+        <circle cx="69.92" cy="99.48" r="1"/>
+        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Buckinghamshire">
-        <g id="Milton Keynes">
-          <circle cx="75.50" cy="110.91" r="1"/>
-          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Stoke-on-Trent">
+        <circle cx="65.39" cy="98.91" r="1"/>
+        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gwent (county)">
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Lincoln">
+        <circle cx="77.27" cy="97.78" r="1"/>
+        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="South Glamorgan">
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Sheffield">
+        <circle cx="69.35" cy="94.39" r="1"/>
+        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Glamorgan">
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Doncaster">
+        <circle cx="72.613" cy="92.65" r="1"/>
+        <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Stirling (council area)">
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Manchester">
+        <circle cx="64.83" cy="93.26" r="1"/>
+        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Perth and Kinross">
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Salford">
+        <circle cx="63.92" cy="93.48" r="1"/>
+        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Highland (council area)">
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Liverpool">
+        <circle cx="59.17" cy="94.39" r="1"/>
+        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Fife">
-        <g id="Dunfermline">
-          <circle cx="55.61" cy="61.85" r="1"/>
-          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chester">
+        <circle cx="60.3" cy="96.65" r="1"/>
+        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Down">
-        <g id="Bangor">
-          <circle cx="39.00" cy="79.86" r="1"/>
-          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Asaph">
+        <circle cx="56.91" cy="96.65" r="1"/>
+        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Londonderry">
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wrexham">
+        <circle cx="59.30" cy="97.79" r="1"/>
+        <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Armagh / County Down">
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Bangor, Gwynedd">
+        <circle cx="50.69" cy="96.65" r="1"/>
+        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Armagh">
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Kingston upon Hull">
+        <circle cx="78.4" cy="89.3" r="1"/>
+        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Antrim / County Down">
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wakefield">
+        <circle cx="70.49" cy="90.99" r="1"/>
+        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Leeds">
+        <circle cx="69.35" cy="89.3" r="1"/>
+        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bradford">
+        <circle cx="67.09" cy="89.3" r="1"/>
+        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Preston">
+        <circle cx="61.43" cy="89.3" r="1"/>
+        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lancaster">
+        <circle cx="61.43" cy="86.47" r="1"/>
+        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="York">
+        <circle cx="72.75" cy="87.6" r="1"/>
+        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Ripon">
+        <circle cx="69.92" cy="85.34" r="1"/>
+        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Durham">
+        <circle cx="69.35" cy="78.55" r="1"/>
+        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Sunderland">
+        <circle cx="69.92" cy="76.29" r="1"/>
+        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newcastle upon Tyne">
+        <circle cx="68.79" cy="75.15" r="1"/>
+        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Carlisle">
+        <circle cx="60.3" cy="75.72" r="1"/>
+        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Dunfermline">
+        <circle cx="55.61" cy="61.85" r="1"/>
+        <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Stirling">
+        <circle cx="51.35" cy="61.00" r="1"/>
+        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Perth">
+        <circle cx="54.72" cy="58.42" r="1"/>
+        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Inverness">
+        <circle cx="49.39" cy="44.2" r="1"/>
+        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Derry">
+        <circle cx="27.11" cy="75.92" r="1"/>
+        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newry">
+        <circle cx="33.87" cy="86.58" r="1"/>
+        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bangor, County Down">
+        <circle cx="39.00" cy="79.86" r="1"/>
+        <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Armagh">
+        <circle cx="31.45" cy="84.59" r="1"/>
+        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Belfast">
+        <circle cx="36.41" cy="80.88" r="1"/>
+        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lisburn">
+        <circle cx="34.64" cy="81.71" r="1"/>
+        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
     </g>
     <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/City - Map.html
+++ b/src/note_models/UK_Geog/templates/City - Map.html
@@ -9,10 +9,18 @@
       transform-origin: center;
       transform: scale(2);
     }
+    .info {
+      max-width: 30em;
+      margin: 0.75em auto;
+      color: #333;
+      font-size: 90%;
+      font-style: italic;
+    }
   </style>
   <header>
     <div class="type">City</div>
     <div class="value value--top">{{City}}</div>
+    {{#Info}}<div class="info">Hint: {{Info}}</div>{{/Info}}
 
     <hr>
 
@@ -572,10 +580,18 @@
       animation: jump 0.75s;
       animation-iteration-count: infinite;
     }
+    .info {
+      max-width: 30em;
+      margin: 0.75em auto;
+      color: #333;
+      font-size: 90%;
+      font-style: italic;
+    }
 </style>
 <header>
   <div class="type">City</div>
   <div class="value value--top">{{City}}</div>
+  {{#Info}}<div class="info">{{Info}}</div>{{/Info}}
 
   <hr>
 

--- a/src/note_models/UK_Geog/templates/City - Map.html
+++ b/src/note_models/UK_Geog/templates/City - Map.html
@@ -256,6 +256,14 @@
             <circle cx="85.19" cy="113.62" r="1"/>
             <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
+          <g id="Colchester">
+            <circle cx="88.03" cy="112.06" r="1"/>
+            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Southend-on-Sea">
+            <circle cx="86.81" cy="116.72" r="1"/>
+            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
         <g id="Gloucestershire">
           <g id="Gloucester">
@@ -350,6 +358,10 @@
           </g>
         </g>
         <g id="South Yorkshire">
+          <g id="Doncaster">
+            <circle cx="72.613" cy="92.65" r="1"/>
+            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
           <g id="Sheffield">
             <circle cx="69.35" cy="94.39" r="1"/>
             <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -381,6 +393,10 @@
           <g id="St Asaph">
             <circle cx="56.91" cy="96.65" r="1"/>
             <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wrexham">
+            <circle cx="59.30" cy="97.79" r="1"/>
+            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="Gwynedd">
@@ -451,6 +467,12 @@
             <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
+        <g id="Buckinghamshire">
+          <g id="Milton Keynes">
+            <circle cx="75.50" cy="110.91" r="1"/>
+            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
         <g id="Gwent (county)">
           <g id="Newport">
             <circle cx="58.04" cy="115.88" r="1"/>
@@ -485,6 +507,18 @@
           <g id="Inverness">
             <circle cx="49.39" cy="44.2" r="1"/>
             <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="Fife">
+          <g id="Dunfermline">
+            <circle cx="55.61" cy="61.85" r="1"/>
+            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="County Down">
+          <g id="Bangor">
+            <circle cx="39.00" cy="79.86" r="1"/>
+            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="County Londonderry">
@@ -785,6 +819,14 @@
           <circle cx="85.19" cy="113.62" r="1"/>
           <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
       <g id="Gloucestershire">
         <g id="Gloucester">
@@ -879,6 +921,10 @@
         </g>
       </g>
       <g id="South Yorkshire">
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
         <g id="Sheffield">
           <circle cx="69.35" cy="94.39" r="1"/>
           <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -910,6 +956,10 @@
         <g id="St Asaph">
           <circle cx="56.91" cy="96.65" r="1"/>
           <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <g id="Gwynedd">
@@ -980,6 +1030,12 @@
           <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
+      <g id="Buckinghamshire">
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
       <g id="Gwent (county)">
         <g id="Newport">
           <circle cx="58.04" cy="115.88" r="1"/>
@@ -1014,6 +1070,18 @@
         <g id="Inverness">
           <circle cx="49.39" cy="44.2" r="1"/>
           <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
+      <g id="Fife">
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
+      <g id="County Down">
+        <g id="Bangor">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <g id="County Londonderry">

--- a/src/note_models/UK_Geog/templates/City - Map.html
+++ b/src/note_models/UK_Geog/templates/City - Map.html
@@ -177,385 +177,285 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Somerset">
-          <g id="Bath">
-            <circle cx="63.13" cy="119.28" r="1"/>
-            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wells">
-            <circle cx="60.87" cy="120.41" r="1"/>
-            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cornwall">
-          <g id="Truro">
-            <circle cx="42.77" cy="132.85" r="1"/>
-            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Decon">
-          <g id="Plymouth">
-            <circle cx="50.12" cy="130.59" r="1"/>
-            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Exeter">
-            <circle cx="54.08" cy="127.2" r="1"/>
-            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Wiltshire">
-          <g id="Salisbury">
-            <circle cx="67.66" cy="122.1" r="1"/>
-            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hampshire">
-          <g id="Southampton">
-            <circle cx="71.5" cy="125" r="1"/>
-            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Portsmouth">
-            <circle cx="73.5" cy="125.5" r="1"/>
-            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Winchester">
-            <circle cx="72.3" cy="122.1" r="1"/>
-            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Sussex">
-          <g id="Chichester">
-            <circle cx="75.58" cy="124.93" r="1"/>
-            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Sussex">
-          <g id="Brighton and Hove">
-            <circle cx="80.67" cy="124.93" r="1"/>
-            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Kent">
-          <g id="Canterbury">
-            <circle cx="89.94" cy="119.84" r="1"/>
-            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater London">
-          <g id="City of Westminster">
-            <circle cx="79.54" cy="117.01" r="1"/>
-            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Oxfordshire">
-          <g id="Oxford">
-            <circle cx="71.62" cy="113.62" r="1"/>
-            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hertfordshire">
-          <g id="St Albans">
-            <circle cx="78.97" cy="113.62" r="1"/>
-            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Essex">
-          <g id="Chelmsford">
-            <circle cx="85.19" cy="113.62" r="1"/>
-            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Colchester">
-            <circle cx="88.03" cy="112.06" r="1"/>
-            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Southend-on-Sea">
-            <circle cx="86.81" cy="116.72" r="1"/>
-            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gloucestershire">
-          <g id="Gloucester">
-            <circle cx="64.26" cy="113.05" r="1"/>
-            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Dyfed">
-          <g id="St Davids">
-            <circle cx="43.67" cy="112.49" r="1"/>
-            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Herefordshire">
-          <g id="Hereford">
-            <circle cx="61.1" cy="110.79" r="1"/>
-            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Worcestershire">
-          <g id="Worcester">
-            <circle cx="64.83" cy="109.09" r="1"/>
-            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cambridgeshire">
-          <g id="Cambridge">
-            <circle cx="81.23" cy="108.53" r="1"/>
-            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ely">
-            <circle cx="81.57" cy="106.27" r="1"/>
-            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Peterborough">
-            <circle cx="78.97" cy="104" r="1"/>
-            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Midlands (county)">
-          <g id="Coventry">
-            <circle cx="69.35" cy="106.27" r="1"/>
-            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Birmingham">
-            <circle cx="67.09" cy="105.14" r="1"/>
-            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wolverhampton">
-            <circle cx="65.39" cy="104" r="1"/>
-            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g if="Norfolk">
-          <g id="Norwich">
-            <circle cx="89.72" cy="103.44" r="1"/>
-            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Leicestershire">
-          <g id="Leicester">
-            <circle cx="72.52" cy="103.44" r="1"/>
-            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Staffordshire">
-          <g id="Lichfield">
-            <circle cx="67.88" cy="103.44" r="1"/>
-            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Stoke-on-Trent">
-            <circle cx="65.39" cy="98.91" r="1"/>
-            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Nottinghamshire">
-          <g id="Nottingham">
-            <circle cx="72.52" cy="100.04" r="1"/>
-            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Derbyshire">
-          <g id="Derby">
-            <circle cx="69.92" cy="99.48" r="1"/>
-            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lincolnshire">
-          <g id="Lincoln">
-            <circle cx="77.27" cy="97.78" r="1"/>
-            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Yorkshire">
-          <g id="Doncaster">
-            <circle cx="72.613" cy="92.65" r="1"/>
-            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Sheffield">
-            <circle cx="69.35" cy="94.39" r="1"/>
-            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater Manchester">
-          <g id="Manchester">
-            <circle cx="64.83" cy="93.26" r="1"/>
-            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Salford">
-            <circle cx="63.92" cy="93.48" r="1"/>
-            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Merseyside">
-          <g id="Liverpool">
-            <circle cx="59.17" cy="94.39" r="1"/>
-            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cheshire">
-          <g id="Chester">
-            <circle cx="60.3" cy="96.65" r="1"/>
-            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Clwyd">
-          <g id="St Asaph">
-            <circle cx="56.91" cy="96.65" r="1"/>
-            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wrexham">
-            <circle cx="59.30" cy="97.79" r="1"/>
-            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwynedd">
-          <g id="Bangor">
-            <circle cx="50.69" cy="96.65" r="1"/>
-            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Riding of Yorkshire">
-          <g id="Kingston upon Hull">
-            <circle cx="78.4" cy="89.3" r="1"/>
-            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Yorkshire">
-          <g id="Wakefield">
-            <circle cx="70.49" cy="90.99" r="1"/>
-            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Leeds">
-            <circle cx="69.35" cy="89.3" r="1"/>
-            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Bradford">
-            <circle cx="67.09" cy="89.3" r="1"/>
-            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lancashire">
-          <g id="Preston">
-            <circle cx="61.43" cy="89.3" r="1"/>
-            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lancaster">
-            <circle cx="61.43" cy="86.47" r="1"/>
-            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="North Yorkshire">
-          <g id="York">
-            <circle cx="72.75" cy="87.6" r="1"/>
-            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ripon">
-            <circle cx="69.92" cy="85.34" r="1"/>
-            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Durham">
-          <g id="Durham">
-            <circle cx="69.35" cy="78.55" r="1"/>
-            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Tyne and Wear">
-          <g id="Sunderland">
-            <circle cx="69.92" cy="76.29" r="1"/>
-            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newcastle upon Tyne">
-            <circle cx="68.79" cy="75.15" r="1"/>
-            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cumbria">
-          <g id="Carlisle">
-            <circle cx="60.3" cy="75.72" r="1"/>
-            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Buckinghamshire">
-          <g id="Milton Keynes">
-            <circle cx="75.50" cy="110.91" r="1"/>
-            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwent (county)">
-          <g id="Newport">
-            <circle cx="58.04" cy="115.88" r="1"/>
-            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Glamorgan">
-          <g id="Cardiff">
-            <circle cx="56.91" cy="117.01" r="1"/>
-            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Glamorgan">
-          <g id="Swansea">
-            <circle cx="52.95" cy="114.75" r="1"/>
-            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Stirling (council area)">
-          <g id="Stirling">
-            <circle cx="51.35" cy="61.00" r="1"/>
-            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Perth and Kinross">
-          <g id="Perth">
-            <circle cx="54.72" cy="58.42" r="1"/>
-            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Highland (council area)">
-          <g id="Inverness">
-            <circle cx="49.39" cy="44.2" r="1"/>
-            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Fife">
-          <g id="Dunfermline">
-            <circle cx="55.61" cy="61.85" r="1"/>
-            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Down">
-          <g id="Bangor">
-            <circle cx="39.00" cy="79.86" r="1"/>
-            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Londonderry">
-          <g id="Derry">
-            <circle cx="27.11" cy="75.92" r="1"/>
-            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh / County Down">
-          <g id="Newry">
-            <circle cx="33.87" cy="86.58" r="1"/>
-            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bangor, Gwynedd">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh">
-          <g id="Armagh">
-            <circle cx="31.45" cy="84.59" r="1"/>
-            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Antrim / County Down">
-          <g id="Belfast">
-            <circle cx="36.41" cy="80.88" r="1"/>
-            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lisburn">
-            <circle cx="34.64" cy="81.71" r="1"/>
-            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bangor, County Down">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -568,9 +468,7 @@
 --
 
 <style>
-    [id='Cities'] > :not([id='{{MacroLocation}}']),
-    [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
-    [id='Bodies of Water'] {
+    [id='Cities'] > :not([id='{{Location}}']), [id='Bodies of Water'] {
         visibility: hidden;
     }
     [id='{{City}}'].cityCounty {
@@ -748,385 +646,285 @@
       </g>
     </g>
     <g id="Cities">
-      <g id="Somerset">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Bath">
+        <circle cx="63.13" cy="119.28" r="1"/>
+        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cornwall">
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Truro">
+        <circle cx="42.77" cy="132.85" r="1"/>
+        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Decon">
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Plymouth">
+        <circle cx="50.12" cy="130.59" r="1"/>
+        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Wiltshire">
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Exeter">
+        <circle cx="54.08" cy="127.2" r="1"/>
+        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Hampshire">
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wells">
+        <circle cx="60.87" cy="120.41" r="1"/>
+        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Sussex">
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Salisbury">
+        <circle cx="67.66" cy="122.1" r="1"/>
+        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="East Sussex">
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Southampton">
+        <circle cx="71.5" cy="125" r="1"/>
+        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Kent">
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Portsmouth">
+        <circle cx="73.5" cy="125.5" r="1"/>
+        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Greater London">
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chichester">
+        <circle cx="75.58" cy="124.93" r="1"/>
+        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Oxfordshire">
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Winchester">
+        <circle cx="72.3" cy="122.1" r="1"/>
+        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Hertfordshire">
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Brighton and Hove">
+        <circle cx="80.67" cy="124.93" r="1"/>
+        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Essex">
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Colchester">
-          <circle cx="88.03" cy="112.06" r="1"/>
-          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Southend-on-Sea">
-          <circle cx="86.81" cy="116.72" r="1"/>
-          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Canterbury">
+        <circle cx="89.94" cy="119.84" r="1"/>
+        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gloucestershire">
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="City of Westminster">
+        <circle cx="79.54" cy="117.01" r="1"/>
+        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Dyfed">
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Southend-on-Sea">
+        <circle cx="86.81" cy="116.72" r="1"/>
+        <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Herefordshire">
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Oxford">
+        <circle cx="71.62" cy="113.62" r="1"/>
+        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Worcestershire">
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Albans">
+        <circle cx="78.97" cy="113.62" r="1"/>
+        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cambridgeshire">
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chelmsford">
+        <circle cx="85.19" cy="113.62" r="1"/>
+        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Midlands (county)">
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Newport">
+        <circle cx="58.04" cy="115.88" r="1"/>
+        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g if="Norfolk">
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Cardiff">
+        <circle cx="56.91" cy="117.01" r="1"/>
+        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Leicestershire">
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Swansea">
+        <circle cx="52.95" cy="114.75" r="1"/>
+        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Staffordshire">
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Gloucester">
+        <circle cx="64.26" cy="113.05" r="1"/>
+        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Nottinghamshire">
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Colchester">
+        <circle cx="88.03" cy="112.06" r="1"/>
+        <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Derbyshire">
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Davids">
+        <circle cx="43.67" cy="112.49" r="1"/>
+        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Lincolnshire">
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Milton Keynes">
+        <circle cx="75.50" cy="110.91" r="1"/>
+        <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="South Yorkshire">
-        <g id="Doncaster">
-          <circle cx="72.613" cy="92.65" r="1"/>
-          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Hereford">
+        <circle cx="61.1" cy="110.79" r="1"/>
+        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Greater Manchester">
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Worcester">
+        <circle cx="64.83" cy="109.09" r="1"/>
+        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Merseyside">
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Cambridge">
+        <circle cx="81.23" cy="108.53" r="1"/>
+        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cheshire">
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Ely">
+        <circle cx="81.57" cy="106.27" r="1"/>
+        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Clwyd">
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wrexham">
-          <circle cx="59.30" cy="97.79" r="1"/>
-          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Coventry">
+        <circle cx="69.35" cy="106.27" r="1"/>
+        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gwynedd">
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Birmingham">
+        <circle cx="67.09" cy="105.14" r="1"/>
+        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="East Riding of Yorkshire">
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wolverhampton">
+        <circle cx="65.39" cy="104" r="1"/>
+        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Yorkshire">
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Norwich">
+        <circle cx="89.72" cy="103.44" r="1"/>
+        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Lancashire">
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Peterborough">
+        <circle cx="78.97" cy="104" r="1"/>
+        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="North Yorkshire">
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Leicester">
+        <circle cx="72.52" cy="103.44" r="1"/>
+        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Durham">
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Lichfield">
+        <circle cx="67.88" cy="103.44" r="1"/>
+        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Tyne and Wear">
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Nottingham">
+        <circle cx="72.52" cy="100.04" r="1"/>
+        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cumbria">
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Derby">
+        <circle cx="69.92" cy="99.48" r="1"/>
+        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Buckinghamshire">
-        <g id="Milton Keynes">
-          <circle cx="75.50" cy="110.91" r="1"/>
-          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Stoke-on-Trent">
+        <circle cx="65.39" cy="98.91" r="1"/>
+        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gwent (county)">
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Lincoln">
+        <circle cx="77.27" cy="97.78" r="1"/>
+        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="South Glamorgan">
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Sheffield">
+        <circle cx="69.35" cy="94.39" r="1"/>
+        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Glamorgan">
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Doncaster">
+        <circle cx="72.613" cy="92.65" r="1"/>
+        <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Stirling (council area)">
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Manchester">
+        <circle cx="64.83" cy="93.26" r="1"/>
+        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Perth and Kinross">
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Salford">
+        <circle cx="63.92" cy="93.48" r="1"/>
+        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Highland (council area)">
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Liverpool">
+        <circle cx="59.17" cy="94.39" r="1"/>
+        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Fife">
-        <g id="Dunfermline">
-          <circle cx="55.61" cy="61.85" r="1"/>
-          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chester">
+        <circle cx="60.3" cy="96.65" r="1"/>
+        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Down">
-        <g id="Bangor">
-          <circle cx="39.00" cy="79.86" r="1"/>
-          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Asaph">
+        <circle cx="56.91" cy="96.65" r="1"/>
+        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Londonderry">
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wrexham">
+        <circle cx="59.30" cy="97.79" r="1"/>
+        <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Armagh / County Down">
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Bangor, Gwynedd">
+        <circle cx="50.69" cy="96.65" r="1"/>
+        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Armagh">
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Kingston upon Hull">
+        <circle cx="78.4" cy="89.3" r="1"/>
+        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Antrim / County Down">
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wakefield">
+        <circle cx="70.49" cy="90.99" r="1"/>
+        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Leeds">
+        <circle cx="69.35" cy="89.3" r="1"/>
+        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bradford">
+        <circle cx="67.09" cy="89.3" r="1"/>
+        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Preston">
+        <circle cx="61.43" cy="89.3" r="1"/>
+        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lancaster">
+        <circle cx="61.43" cy="86.47" r="1"/>
+        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="York">
+        <circle cx="72.75" cy="87.6" r="1"/>
+        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Ripon">
+        <circle cx="69.92" cy="85.34" r="1"/>
+        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Durham">
+        <circle cx="69.35" cy="78.55" r="1"/>
+        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Sunderland">
+        <circle cx="69.92" cy="76.29" r="1"/>
+        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newcastle upon Tyne">
+        <circle cx="68.79" cy="75.15" r="1"/>
+        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Carlisle">
+        <circle cx="60.3" cy="75.72" r="1"/>
+        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Dunfermline">
+        <circle cx="55.61" cy="61.85" r="1"/>
+        <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Stirling">
+        <circle cx="51.35" cy="61.00" r="1"/>
+        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Perth">
+        <circle cx="54.72" cy="58.42" r="1"/>
+        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Inverness">
+        <circle cx="49.39" cy="44.2" r="1"/>
+        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Derry">
+        <circle cx="27.11" cy="75.92" r="1"/>
+        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newry">
+        <circle cx="33.87" cy="86.58" r="1"/>
+        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bangor, County Down">
+        <circle cx="39.00" cy="79.86" r="1"/>
+        <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Armagh">
+        <circle cx="31.45" cy="84.59" r="1"/>
+        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Belfast">
+        <circle cx="36.41" cy="80.88" r="1"/>
+        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lisburn">
+        <circle cx="34.64" cy="81.71" r="1"/>
+        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
     </g>
     <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/City - Map.html
+++ b/src/note_models/UK_Geog/templates/City - Map.html
@@ -169,261 +169,356 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Somerset">
+          <g id="Bath">
+            <circle cx="63.13" cy="119.28" r="1"/>
+            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wells">
+            <circle cx="60.87" cy="120.41" r="1"/>
+            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cornwall">
+          <g id="Truro">
+            <circle cx="42.77" cy="132.85" r="1"/>
+            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Decon">
+          <g id="Plymouth">
+            <circle cx="50.12" cy="130.59" r="1"/>
+            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Exeter">
+            <circle cx="54.08" cy="127.2" r="1"/>
+            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Wiltshire">
+          <g id="Salisbury">
+            <circle cx="67.66" cy="122.1" r="1"/>
+            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hampshire">
+          <g id="Southampton">
+            <circle cx="71.5" cy="125" r="1"/>
+            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Portsmouth">
+            <circle cx="73.5" cy="125.5" r="1"/>
+            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Winchester">
+            <circle cx="72.3" cy="122.1" r="1"/>
+            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Sussex">
+          <g id="Chichester">
+            <circle cx="75.58" cy="124.93" r="1"/>
+            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Sussex">
+          <g id="Brighton and Hove">
+            <circle cx="80.67" cy="124.93" r="1"/>
+            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Kent">
+          <g id="Canterbury">
+            <circle cx="89.94" cy="119.84" r="1"/>
+            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater London">
+          <g id="City of Westminster">
+            <circle cx="79.54" cy="117.01" r="1"/>
+            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Oxfordshire">
+          <g id="Oxford">
+            <circle cx="71.62" cy="113.62" r="1"/>
+            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hertfordshire">
+          <g id="St Albans">
+            <circle cx="78.97" cy="113.62" r="1"/>
+            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Essex">
+          <g id="Chelmsford">
+            <circle cx="85.19" cy="113.62" r="1"/>
+            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gloucestershire">
+          <g id="Gloucester">
+            <circle cx="64.26" cy="113.05" r="1"/>
+            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Dyfed">
+          <g id="St Davids">
+            <circle cx="43.67" cy="112.49" r="1"/>
+            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Herefordshire">
+          <g id="Hereford">
+            <circle cx="61.1" cy="110.79" r="1"/>
+            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Worcestershire">
+          <g id="Worcester">
+            <circle cx="64.83" cy="109.09" r="1"/>
+            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cambridgeshire">
+          <g id="Cambridge">
+            <circle cx="81.23" cy="108.53" r="1"/>
+            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ely">
+            <circle cx="81.57" cy="106.27" r="1"/>
+            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Peterborough">
+            <circle cx="78.97" cy="104" r="1"/>
+            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Midlands (county)">
+          <g id="Coventry">
+            <circle cx="69.35" cy="106.27" r="1"/>
+            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Birmingham">
+            <circle cx="67.09" cy="105.14" r="1"/>
+            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wolverhampton">
+            <circle cx="65.39" cy="104" r="1"/>
+            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g if="Norfolk">
+          <g id="Norwich">
+            <circle cx="89.72" cy="103.44" r="1"/>
+            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Leicestershire">
+          <g id="Leicester">
+            <circle cx="72.52" cy="103.44" r="1"/>
+            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Staffordshire">
+          <g id="Lichfield">
+            <circle cx="67.88" cy="103.44" r="1"/>
+            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Stoke-on-Trent">
+            <circle cx="65.39" cy="98.91" r="1"/>
+            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Nottinghamshire">
+          <g id="Nottingham">
+            <circle cx="72.52" cy="100.04" r="1"/>
+            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Derbyshire">
+          <g id="Derby">
+            <circle cx="69.92" cy="99.48" r="1"/>
+            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lincolnshire">
+          <g id="Lincoln">
+            <circle cx="77.27" cy="97.78" r="1"/>
+            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Yorkshire">
+          <g id="Sheffield">
+            <circle cx="69.35" cy="94.39" r="1"/>
+            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater Manchester">
+          <g id="Manchester">
+            <circle cx="64.83" cy="93.26" r="1"/>
+            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Salford">
+            <circle cx="63.92" cy="93.48" r="1"/>
+            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Merseyside">
+          <g id="Liverpool">
+            <circle cx="59.17" cy="94.39" r="1"/>
+            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cheshire">
+          <g id="Chester">
+            <circle cx="60.3" cy="96.65" r="1"/>
+            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Clwyd">
+          <g id="St Asaph">
+            <circle cx="56.91" cy="96.65" r="1"/>
+            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwynedd">
+          <g id="Bangor">
+            <circle cx="50.69" cy="96.65" r="1"/>
+            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Riding of Yorkshire">
+          <g id="Kingston upon Hull">
+            <circle cx="78.4" cy="89.3" r="1"/>
+            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Yorkshire">
+          <g id="Wakefield">
+            <circle cx="70.49" cy="90.99" r="1"/>
+            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Leeds">
+            <circle cx="69.35" cy="89.3" r="1"/>
+            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bradford">
+            <circle cx="67.09" cy="89.3" r="1"/>
+            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lancashire">
+          <g id="Preston">
+            <circle cx="61.43" cy="89.3" r="1"/>
+            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lancaster">
+            <circle cx="61.43" cy="86.47" r="1"/>
+            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="North Yorkshire">
+          <g id="York">
+            <circle cx="72.75" cy="87.6" r="1"/>
+            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ripon">
+            <circle cx="69.92" cy="85.34" r="1"/>
+            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Durham">
+          <g id="Durham">
+            <circle cx="69.35" cy="78.55" r="1"/>
+            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Tyne and Wear">
+          <g id="Sunderland">
+            <circle cx="69.92" cy="76.29" r="1"/>
+            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newcastle upon Tyne">
+            <circle cx="68.79" cy="75.15" r="1"/>
+            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cumbria">
+          <g id="Carlisle">
+            <circle cx="60.3" cy="75.72" r="1"/>
+            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwent (county)">
+          <g id="Newport">
+            <circle cx="58.04" cy="115.88" r="1"/>
+            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Glamorgan">
+          <g id="Cardiff">
+            <circle cx="56.91" cy="117.01" r="1"/>
+            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Glamorgan">
+          <g id="Swansea">
+            <circle cx="52.95" cy="114.75" r="1"/>
+            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Stirling (council area)">
+          <g id="Stirling">
+            <circle cx="51.35" cy="61.00" r="1"/>
+            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Perth and Kinross">
+          <g id="Perth">
+            <circle cx="54.72" cy="58.42" r="1"/>
+            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Highland (council area)">
+          <g id="Inverness">
+            <circle cx="49.39" cy="44.2" r="1"/>
+            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Londonderry">
+          <g id="Derry">
+            <circle cx="27.11" cy="75.92" r="1"/>
+            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh / County Down">
+          <g id="Newry">
+            <circle cx="33.87" cy="86.58" r="1"/>
+            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh">
+          <g id="Armagh">
+            <circle cx="31.45" cy="84.59" r="1"/>
+            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Antrim / County Down">
+          <g id="Belfast">
+            <circle cx="36.41" cy="80.88" r="1"/>
+            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lisburn">
+            <circle cx="34.64" cy="81.71" r="1"/>
+            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
     </svg>
+
  
   </div>
 {{/City}}
@@ -431,7 +526,9 @@
 --
 
 <style>
-    [id='Bodies of Water'], [id='Cities'] > :not([id='{{City}}']) {
+    [id='Cities'] > :not([id='{{MacroLocation}}']),
+    [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
+    [id='Bodies of Water'] {
         visibility: hidden;
     }
     [id='{{City}}'].cityCounty {
@@ -601,261 +698,356 @@
       </g>
     </g>
     <g id="Cities">
-      <g id="Bath">
-        <circle cx="63.13" cy="119.28" r="1"/>
-        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Somerset">
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Truro">
-        <circle cx="42.77" cy="132.85" r="1"/>
-        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cornwall">
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Plymouth">
-        <circle cx="50.12" cy="130.59" r="1"/>
-        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Decon">
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Exeter">
-        <circle cx="54.08" cy="127.2" r="1"/>
-        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Wiltshire">
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wells">
-        <circle cx="60.87" cy="120.41" r="1"/>
-        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Hampshire">
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Salisbury">
-        <circle cx="67.66" cy="122.1" r="1"/>
-        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Sussex">
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Southampton">
-        <circle cx="71.5" cy="125" r="1"/>
-        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="East Sussex">
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Portsmouth">
-        <circle cx="73.5" cy="125.5" r="1"/>
-        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Kent">
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chichester">
-        <circle cx="75.58" cy="124.93" r="1"/>
-        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Greater London">
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Winchester">
-        <circle cx="72.3" cy="122.1" r="1"/>
-        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Oxfordshire">
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Brighton and Hove">
-        <circle cx="80.67" cy="124.93" r="1"/>
-        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Hertfordshire">
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Canterbury">
-        <circle cx="89.94" cy="119.84" r="1"/>
-        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Essex">
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="City of Westminster">
-        <circle cx="79.54" cy="117.01" r="1"/>
-        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gloucestershire">
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Oxford">
-        <circle cx="71.62" cy="113.62" r="1"/>
-        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Dyfed">
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Albans">
-        <circle cx="78.97" cy="113.62" r="1"/>
-        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Herefordshire">
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chelmsford">
-        <circle cx="85.19" cy="113.62" r="1"/>
-        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Worcestershire">
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Newport">
-        <circle cx="58.04" cy="115.88" r="1"/>
-        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cambridgeshire">
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Cardiff">
-        <circle cx="56.91" cy="117.01" r="1"/>
-        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Midlands (county)">
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Swansea">
-        <circle cx="52.95" cy="114.75" r="1"/>
-        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g if="Norfolk">
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Gloucester">
-        <circle cx="64.26" cy="113.05" r="1"/>
-        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Leicestershire">
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Davids">
-        <circle cx="43.67" cy="112.49" r="1"/>
-        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Staffordshire">
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Hereford">
-        <circle cx="61.1" cy="110.79" r="1"/>
-        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Nottinghamshire">
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Worcester">
-        <circle cx="64.83" cy="109.09" r="1"/>
-        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Derbyshire">
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Cambridge">
-        <circle cx="81.23" cy="108.53" r="1"/>
-        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Lincolnshire">
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Ely">
-        <circle cx="81.57" cy="106.27" r="1"/>
-        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="South Yorkshire">
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Coventry">
-        <circle cx="69.35" cy="106.27" r="1"/>
-        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Greater Manchester">
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Birmingham">
-        <circle cx="67.09" cy="105.14" r="1"/>
-        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Merseyside">
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wolverhampton">
-        <circle cx="65.39" cy="104" r="1"/>
-        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cheshire">
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Norwich">
-        <circle cx="89.72" cy="103.44" r="1"/>
-        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Clwyd">
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Peterborough">
-        <circle cx="78.97" cy="104" r="1"/>
-        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gwynedd">
+        <g id="Bangor">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Leicester">
-        <circle cx="72.52" cy="103.44" r="1"/>
-        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="East Riding of Yorkshire">
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Lichfield">
-        <circle cx="67.88" cy="103.44" r="1"/>
-        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Yorkshire">
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Nottingham">
-        <circle cx="72.52" cy="100.04" r="1"/>
-        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Lancashire">
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Derby">
-        <circle cx="69.92" cy="99.48" r="1"/>
-        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="North Yorkshire">
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Stoke-on-Trent">
-        <circle cx="65.39" cy="98.91" r="1"/>
-        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Durham">
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Lincoln">
-        <circle cx="77.27" cy="97.78" r="1"/>
-        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Tyne and Wear">
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Sheffield">
-        <circle cx="69.35" cy="94.39" r="1"/>
-        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cumbria">
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Manchester">
-        <circle cx="64.83" cy="93.26" r="1"/>
-        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gwent (county)">
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Salford">
-        <circle cx="63.92" cy="93.48" r="1"/>
-        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="South Glamorgan">
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Liverpool">
-        <circle cx="59.17" cy="94.39" r="1"/>
-        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Glamorgan">
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chester">
-        <circle cx="60.3" cy="96.65" r="1"/>
-        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Stirling (council area)">
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Asaph">
-        <circle cx="56.91" cy="96.65" r="1"/>
-        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Perth and Kinross">
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Bangor">
-        <circle cx="50.69" cy="96.65" r="1"/>
-        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Highland (council area)">
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Kingston upon Hull">
-        <circle cx="78.4" cy="89.3" r="1"/>
-        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Londonderry">
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wakefield">
-        <circle cx="70.49" cy="90.99" r="1"/>
-        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Armagh / County Down">
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Leeds">
-        <circle cx="69.35" cy="89.3" r="1"/>
-        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Armagh">
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Bradford">
-        <circle cx="67.09" cy="89.3" r="1"/>
-        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Preston">
-        <circle cx="61.43" cy="89.3" r="1"/>
-        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lancaster">
-        <circle cx="61.43" cy="86.47" r="1"/>
-        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="York">
-        <circle cx="72.75" cy="87.6" r="1"/>
-        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Ripon">
-        <circle cx="69.92" cy="85.34" r="1"/>
-        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Durham">
-        <circle cx="69.35" cy="78.55" r="1"/>
-        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Sunderland">
-        <circle cx="69.92" cy="76.29" r="1"/>
-        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newcastle upon Tyne">
-        <circle cx="68.79" cy="75.15" r="1"/>
-        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Carlisle">
-        <circle cx="60.3" cy="75.72" r="1"/>
-        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Stirling">
-        <circle cx="51.35" cy="61.00" r="1"/>
-        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Perth">
-        <circle cx="54.72" cy="58.42" r="1"/>
-        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Inverness">
-        <circle cx="49.39" cy="44.2" r="1"/>
-        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Derry">
-        <circle cx="27.11" cy="75.92" r="1"/>
-        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newry">
-        <circle cx="33.87" cy="86.58" r="1"/>
-        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Armagh">
-        <circle cx="31.45" cy="84.59" r="1"/>
-        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Belfast">
-        <circle cx="36.41" cy="80.88" r="1"/>
-        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lisburn">
-        <circle cx="34.64" cy="81.71" r="1"/>
-        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Antrim / County Down">
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
     </g>
     <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
   </svg>
+
 
 </div>
 <script>

--- a/src/note_models/UK_Geog/templates/County - Map.html
+++ b/src/note_models/UK_Geog/templates/County - Map.html
@@ -251,6 +251,14 @@
               <circle cx="85.19" cy="113.62" r="1"/>
               <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
+            <g id="Colchester">
+              <circle cx="88.03" cy="112.06" r="1"/>
+              <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Southend-on-Sea">
+              <circle cx="86.81" cy="116.72" r="1"/>
+              <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
           <g id="Gloucestershire">
             <g id="Gloucester">
@@ -345,6 +353,10 @@
             </g>
           </g>
           <g id="South Yorkshire">
+            <g id="Doncaster">
+              <circle cx="72.613" cy="92.65" r="1"/>
+              <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
             <g id="Sheffield">
               <circle cx="69.35" cy="94.39" r="1"/>
               <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -376,6 +388,10 @@
             <g id="St Asaph">
               <circle cx="56.91" cy="96.65" r="1"/>
               <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Wrexham">
+              <circle cx="59.30" cy="97.79" r="1"/>
+              <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
           </g>
           <g id="Gwynedd">
@@ -446,6 +462,12 @@
               <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
           </g>
+          <g id="Buckinghamshire">
+            <g id="Milton Keynes">
+              <circle cx="75.50" cy="110.91" r="1"/>
+              <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+          </g>
           <g id="Gwent (county)">
             <g id="Newport">
               <circle cx="58.04" cy="115.88" r="1"/>
@@ -480,6 +502,18 @@
             <g id="Inverness">
               <circle cx="49.39" cy="44.2" r="1"/>
               <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+          </g>
+          <g id="Fife">
+            <g id="Dunfermline">
+              <circle cx="55.61" cy="61.85" r="1"/>
+              <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+          </g>
+          <g id="County Down">
+            <g id="Bangor">
+              <circle cx="39.00" cy="79.86" r="1"/>
+              <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
           </g>
           <g id="County Londonderry">
@@ -789,6 +823,14 @@
             <circle cx="85.19" cy="113.62" r="1"/>
             <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
+          <g id="Colchester">
+            <circle cx="88.03" cy="112.06" r="1"/>
+            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Southend-on-Sea">
+            <circle cx="86.81" cy="116.72" r="1"/>
+            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
         <g id="Gloucestershire">
           <g id="Gloucester">
@@ -883,6 +925,10 @@
           </g>
         </g>
         <g id="South Yorkshire">
+          <g id="Doncaster">
+            <circle cx="72.613" cy="92.65" r="1"/>
+            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
           <g id="Sheffield">
             <circle cx="69.35" cy="94.39" r="1"/>
             <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -914,6 +960,10 @@
           <g id="St Asaph">
             <circle cx="56.91" cy="96.65" r="1"/>
             <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wrexham">
+            <circle cx="59.30" cy="97.79" r="1"/>
+            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="Gwynedd">
@@ -984,6 +1034,12 @@
             <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
+        <g id="Buckinghamshire">
+          <g id="Milton Keynes">
+            <circle cx="75.50" cy="110.91" r="1"/>
+            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
         <g id="Gwent (county)">
           <g id="Newport">
             <circle cx="58.04" cy="115.88" r="1"/>
@@ -1018,6 +1074,18 @@
           <g id="Inverness">
             <circle cx="49.39" cy="44.2" r="1"/>
             <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="Fife">
+          <g id="Dunfermline">
+            <circle cx="55.61" cy="61.85" r="1"/>
+            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="County Down">
+          <g id="Bangor">
+            <circle cx="39.00" cy="79.86" r="1"/>
+            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="County Londonderry">

--- a/src/note_models/UK_Geog/templates/County - Map.html
+++ b/src/note_models/UK_Geog/templates/County - Map.html
@@ -164,257 +164,351 @@
           </g>
         </g>
         <g id="Cities">
-          <g id="Bath">
-            <circle cx="63.13" cy="119.28" r="1"/>
-            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Somerset">
+            <g id="Bath">
+              <circle cx="63.13" cy="119.28" r="1"/>
+              <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Wells">
+              <circle cx="60.87" cy="120.41" r="1"/>
+              <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Truro">
-            <circle cx="42.77" cy="132.85" r="1"/>
-            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cornwall">
+            <g id="Truro">
+              <circle cx="42.77" cy="132.85" r="1"/>
+              <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Plymouth">
-            <circle cx="50.12" cy="130.59" r="1"/>
-            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Decon">
+            <g id="Plymouth">
+              <circle cx="50.12" cy="130.59" r="1"/>
+              <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Exeter">
+              <circle cx="54.08" cy="127.2" r="1"/>
+              <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Exeter">
-            <circle cx="54.08" cy="127.2" r="1"/>
-            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Wiltshire">
+            <g id="Salisbury">
+              <circle cx="67.66" cy="122.1" r="1"/>
+              <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Wells">
-            <circle cx="60.87" cy="120.41" r="1"/>
-            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Hampshire">
+            <g id="Southampton">
+              <circle cx="71.5" cy="125" r="1"/>
+              <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Portsmouth">
+              <circle cx="73.5" cy="125.5" r="1"/>
+              <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Winchester">
+              <circle cx="72.3" cy="122.1" r="1"/>
+              <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Salisbury">
-            <circle cx="67.66" cy="122.1" r="1"/>
-            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Sussex">
+            <g id="Chichester">
+              <circle cx="75.58" cy="124.93" r="1"/>
+              <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Southampton">
-            <circle cx="71.5" cy="125" r="1"/>
-            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="East Sussex">
+            <g id="Brighton and Hove">
+              <circle cx="80.67" cy="124.93" r="1"/>
+              <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Portsmouth">
-            <circle cx="73.5" cy="125.5" r="1"/>
-            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Kent">
+            <g id="Canterbury">
+              <circle cx="89.94" cy="119.84" r="1"/>
+              <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Chichester">
-            <circle cx="75.58" cy="124.93" r="1"/>
-            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Greater London">
+            <g id="City of Westminster">
+              <circle cx="79.54" cy="117.01" r="1"/>
+              <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Winchester">
-            <circle cx="72.3" cy="122.1" r="1"/>
-            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Oxfordshire">
+            <g id="Oxford">
+              <circle cx="71.62" cy="113.62" r="1"/>
+              <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Brighton and Hove">
-            <circle cx="80.67" cy="124.93" r="1"/>
-            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Hertfordshire">
+            <g id="St Albans">
+              <circle cx="78.97" cy="113.62" r="1"/>
+              <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Canterbury">
-            <circle cx="89.94" cy="119.84" r="1"/>
-            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Essex">
+            <g id="Chelmsford">
+              <circle cx="85.19" cy="113.62" r="1"/>
+              <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="City of Westminster">
-            <circle cx="79.54" cy="117.01" r="1"/>
-            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Gloucestershire">
+            <g id="Gloucester">
+              <circle cx="64.26" cy="113.05" r="1"/>
+              <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Oxford">
-            <circle cx="71.62" cy="113.62" r="1"/>
-            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Dyfed">
+            <g id="St Davids">
+              <circle cx="43.67" cy="112.49" r="1"/>
+              <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="St Albans">
-            <circle cx="78.97" cy="113.62" r="1"/>
-            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Herefordshire">
+            <g id="Hereford">
+              <circle cx="61.1" cy="110.79" r="1"/>
+              <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Chelmsford">
-            <circle cx="85.19" cy="113.62" r="1"/>
-            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Worcestershire">
+            <g id="Worcester">
+              <circle cx="64.83" cy="109.09" r="1"/>
+              <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Newport">
-            <circle cx="58.04" cy="115.88" r="1"/>
-            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cambridgeshire">
+            <g id="Cambridge">
+              <circle cx="81.23" cy="108.53" r="1"/>
+              <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Ely">
+              <circle cx="81.57" cy="106.27" r="1"/>
+              <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Peterborough">
+              <circle cx="78.97" cy="104" r="1"/>
+              <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Cardiff">
-            <circle cx="56.91" cy="117.01" r="1"/>
-            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Midlands (county)">
+            <g id="Coventry">
+              <circle cx="69.35" cy="106.27" r="1"/>
+              <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Birmingham">
+              <circle cx="67.09" cy="105.14" r="1"/>
+              <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Wolverhampton">
+              <circle cx="65.39" cy="104" r="1"/>
+              <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Swansea">
-            <circle cx="52.95" cy="114.75" r="1"/>
-            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g if="Norfolk">
+            <g id="Norwich">
+              <circle cx="89.72" cy="103.44" r="1"/>
+              <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Gloucester">
-            <circle cx="64.26" cy="113.05" r="1"/>
-            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Leicestershire">
+            <g id="Leicester">
+              <circle cx="72.52" cy="103.44" r="1"/>
+              <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="St Davids">
-            <circle cx="43.67" cy="112.49" r="1"/>
-            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Staffordshire">
+            <g id="Lichfield">
+              <circle cx="67.88" cy="103.44" r="1"/>
+              <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Stoke-on-Trent">
+              <circle cx="65.39" cy="98.91" r="1"/>
+              <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Hereford">
-            <circle cx="61.1" cy="110.79" r="1"/>
-            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Nottinghamshire">
+            <g id="Nottingham">
+              <circle cx="72.52" cy="100.04" r="1"/>
+              <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Worcester">
-            <circle cx="64.83" cy="109.09" r="1"/>
-            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Derbyshire">
+            <g id="Derby">
+              <circle cx="69.92" cy="99.48" r="1"/>
+              <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Cambridge">
-            <circle cx="81.23" cy="108.53" r="1"/>
-            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Lincolnshire">
+            <g id="Lincoln">
+              <circle cx="77.27" cy="97.78" r="1"/>
+              <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Ely">
-            <circle cx="81.57" cy="106.27" r="1"/>
-            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="South Yorkshire">
+            <g id="Sheffield">
+              <circle cx="69.35" cy="94.39" r="1"/>
+              <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Coventry">
-            <circle cx="69.35" cy="106.27" r="1"/>
-            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Greater Manchester">
+            <g id="Manchester">
+              <circle cx="64.83" cy="93.26" r="1"/>
+              <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Salford">
+              <circle cx="63.92" cy="93.48" r="1"/>
+              <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Birmingham">
-            <circle cx="67.09" cy="105.14" r="1"/>
-            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Merseyside">
+            <g id="Liverpool">
+              <circle cx="59.17" cy="94.39" r="1"/>
+              <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Wolverhampton">
-            <circle cx="65.39" cy="104" r="1"/>
-            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cheshire">
+            <g id="Chester">
+              <circle cx="60.3" cy="96.65" r="1"/>
+              <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Norwich">
-            <circle cx="89.72" cy="103.44" r="1"/>
-            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Clwyd">
+            <g id="St Asaph">
+              <circle cx="56.91" cy="96.65" r="1"/>
+              <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Peterborough">
-            <circle cx="78.97" cy="104" r="1"/>
-            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Gwynedd">
+            <g id="Bangor">
+              <circle cx="50.69" cy="96.65" r="1"/>
+              <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Leicester">
-            <circle cx="72.52" cy="103.44" r="1"/>
-            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="East Riding of Yorkshire">
+            <g id="Kingston upon Hull">
+              <circle cx="78.4" cy="89.3" r="1"/>
+              <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Lichfield">
-            <circle cx="67.88" cy="103.44" r="1"/>
-            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Yorkshire">
+            <g id="Wakefield">
+              <circle cx="70.49" cy="90.99" r="1"/>
+              <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Leeds">
+              <circle cx="69.35" cy="89.3" r="1"/>
+              <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Bradford">
+              <circle cx="67.09" cy="89.3" r="1"/>
+              <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Nottingham">
-            <circle cx="72.52" cy="100.04" r="1"/>
-            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Lancashire">
+            <g id="Preston">
+              <circle cx="61.43" cy="89.3" r="1"/>
+              <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Lancaster">
+              <circle cx="61.43" cy="86.47" r="1"/>
+              <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Derby">
-            <circle cx="69.92" cy="99.48" r="1"/>
-            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="North Yorkshire">
+            <g id="York">
+              <circle cx="72.75" cy="87.6" r="1"/>
+              <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Ripon">
+              <circle cx="69.92" cy="85.34" r="1"/>
+              <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Stoke-on-Trent">
-            <circle cx="65.39" cy="98.91" r="1"/>
-            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Durham">
+            <g id="Durham">
+              <circle cx="69.35" cy="78.55" r="1"/>
+              <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Lincoln">
-            <circle cx="77.27" cy="97.78" r="1"/>
-            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Tyne and Wear">
+            <g id="Sunderland">
+              <circle cx="69.92" cy="76.29" r="1"/>
+              <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Newcastle upon Tyne">
+              <circle cx="68.79" cy="75.15" r="1"/>
+              <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Sheffield">
-            <circle cx="69.35" cy="94.39" r="1"/>
-            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cumbria">
+            <g id="Carlisle">
+              <circle cx="60.3" cy="75.72" r="1"/>
+              <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Manchester">
-            <circle cx="64.83" cy="93.26" r="1"/>
-            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Gwent (county)">
+            <g id="Newport">
+              <circle cx="58.04" cy="115.88" r="1"/>
+              <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Salford">
-            <circle cx="63.92" cy="93.48" r="1"/>
-            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="South Glamorgan">
+            <g id="Cardiff">
+              <circle cx="56.91" cy="117.01" r="1"/>
+              <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Liverpool">
-            <circle cx="59.17" cy="94.39" r="1"/>
-            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Glamorgan">
+            <g id="Swansea">
+              <circle cx="52.95" cy="114.75" r="1"/>
+              <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Chester">
-            <circle cx="60.3" cy="96.65" r="1"/>
-            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Stirling (council area)">
+            <g id="Stirling">
+              <circle cx="51.35" cy="61.00" r="1"/>
+              <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="St Asaph">
-            <circle cx="56.91" cy="96.65" r="1"/>
-            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Perth and Kinross">
+            <g id="Perth">
+              <circle cx="54.72" cy="58.42" r="1"/>
+              <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Bangor">
-            <circle cx="50.69" cy="96.65" r="1"/>
-            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Highland (council area)">
+            <g id="Inverness">
+              <circle cx="49.39" cy="44.2" r="1"/>
+              <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Kingston upon Hull">
-            <circle cx="78.4" cy="89.3" r="1"/>
-            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Londonderry">
+            <g id="Derry">
+              <circle cx="27.11" cy="75.92" r="1"/>
+              <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Wakefield">
-            <circle cx="70.49" cy="90.99" r="1"/>
-            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Armagh / County Down">
+            <g id="Newry">
+              <circle cx="33.87" cy="86.58" r="1"/>
+              <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Leeds">
-            <circle cx="69.35" cy="89.3" r="1"/>
-            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Armagh">
+            <g id="Armagh">
+              <circle cx="31.45" cy="84.59" r="1"/>
+              <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Bradford">
-            <circle cx="67.09" cy="89.3" r="1"/>
-            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Preston">
-            <circle cx="61.43" cy="89.3" r="1"/>
-            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lancaster">
-            <circle cx="61.43" cy="86.47" r="1"/>
-            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="York">
-            <circle cx="72.75" cy="87.6" r="1"/>
-            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ripon">
-            <circle cx="69.92" cy="85.34" r="1"/>
-            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Durham">
-            <circle cx="69.35" cy="78.55" r="1"/>
-            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Sunderland">
-            <circle cx="69.92" cy="76.29" r="1"/>
-            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newcastle upon Tyne">
-            <circle cx="68.79" cy="75.15" r="1"/>
-            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Carlisle">
-            <circle cx="60.3" cy="75.72" r="1"/>
-            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Stirling">
-            <circle cx="51.35" cy="61.00" r="1"/>
-            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Perth">
-            <circle cx="54.72" cy="58.42" r="1"/>
-            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Inverness">
-            <circle cx="49.39" cy="44.2" r="1"/>
-            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Derry">
-            <circle cx="27.11" cy="75.92" r="1"/>
-            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newry">
-            <circle cx="33.87" cy="86.58" r="1"/>
-            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Armagh">
-            <circle cx="31.45" cy="84.59" r="1"/>
-            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Belfast">
-            <circle cx="36.41" cy="80.88" r="1"/>
-            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lisburn">
-            <circle cx="34.64" cy="81.71" r="1"/>
-            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Antrim / County Down">
+            <g id="Belfast">
+              <circle cx="36.41" cy="80.88" r="1"/>
+              <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Lisburn">
+              <circle cx="34.64" cy="81.71" r="1"/>
+              <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
         </g>
         <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -608,257 +702,351 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Somerset">
+          <g id="Bath">
+            <circle cx="63.13" cy="119.28" r="1"/>
+            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wells">
+            <circle cx="60.87" cy="120.41" r="1"/>
+            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cornwall">
+          <g id="Truro">
+            <circle cx="42.77" cy="132.85" r="1"/>
+            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Decon">
+          <g id="Plymouth">
+            <circle cx="50.12" cy="130.59" r="1"/>
+            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Exeter">
+            <circle cx="54.08" cy="127.2" r="1"/>
+            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Wiltshire">
+          <g id="Salisbury">
+            <circle cx="67.66" cy="122.1" r="1"/>
+            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hampshire">
+          <g id="Southampton">
+            <circle cx="71.5" cy="125" r="1"/>
+            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Portsmouth">
+            <circle cx="73.5" cy="125.5" r="1"/>
+            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Winchester">
+            <circle cx="72.3" cy="122.1" r="1"/>
+            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Sussex">
+          <g id="Chichester">
+            <circle cx="75.58" cy="124.93" r="1"/>
+            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Sussex">
+          <g id="Brighton and Hove">
+            <circle cx="80.67" cy="124.93" r="1"/>
+            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Kent">
+          <g id="Canterbury">
+            <circle cx="89.94" cy="119.84" r="1"/>
+            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater London">
+          <g id="City of Westminster">
+            <circle cx="79.54" cy="117.01" r="1"/>
+            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Oxfordshire">
+          <g id="Oxford">
+            <circle cx="71.62" cy="113.62" r="1"/>
+            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hertfordshire">
+          <g id="St Albans">
+            <circle cx="78.97" cy="113.62" r="1"/>
+            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Essex">
+          <g id="Chelmsford">
+            <circle cx="85.19" cy="113.62" r="1"/>
+            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gloucestershire">
+          <g id="Gloucester">
+            <circle cx="64.26" cy="113.05" r="1"/>
+            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Dyfed">
+          <g id="St Davids">
+            <circle cx="43.67" cy="112.49" r="1"/>
+            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Herefordshire">
+          <g id="Hereford">
+            <circle cx="61.1" cy="110.79" r="1"/>
+            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Worcestershire">
+          <g id="Worcester">
+            <circle cx="64.83" cy="109.09" r="1"/>
+            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cambridgeshire">
+          <g id="Cambridge">
+            <circle cx="81.23" cy="108.53" r="1"/>
+            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ely">
+            <circle cx="81.57" cy="106.27" r="1"/>
+            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Peterborough">
+            <circle cx="78.97" cy="104" r="1"/>
+            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Midlands (county)">
+          <g id="Coventry">
+            <circle cx="69.35" cy="106.27" r="1"/>
+            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Birmingham">
+            <circle cx="67.09" cy="105.14" r="1"/>
+            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wolverhampton">
+            <circle cx="65.39" cy="104" r="1"/>
+            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g if="Norfolk">
+          <g id="Norwich">
+            <circle cx="89.72" cy="103.44" r="1"/>
+            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Leicestershire">
+          <g id="Leicester">
+            <circle cx="72.52" cy="103.44" r="1"/>
+            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Staffordshire">
+          <g id="Lichfield">
+            <circle cx="67.88" cy="103.44" r="1"/>
+            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Stoke-on-Trent">
+            <circle cx="65.39" cy="98.91" r="1"/>
+            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Nottinghamshire">
+          <g id="Nottingham">
+            <circle cx="72.52" cy="100.04" r="1"/>
+            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Derbyshire">
+          <g id="Derby">
+            <circle cx="69.92" cy="99.48" r="1"/>
+            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lincolnshire">
+          <g id="Lincoln">
+            <circle cx="77.27" cy="97.78" r="1"/>
+            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Yorkshire">
+          <g id="Sheffield">
+            <circle cx="69.35" cy="94.39" r="1"/>
+            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater Manchester">
+          <g id="Manchester">
+            <circle cx="64.83" cy="93.26" r="1"/>
+            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Salford">
+            <circle cx="63.92" cy="93.48" r="1"/>
+            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Merseyside">
+          <g id="Liverpool">
+            <circle cx="59.17" cy="94.39" r="1"/>
+            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cheshire">
+          <g id="Chester">
+            <circle cx="60.3" cy="96.65" r="1"/>
+            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Clwyd">
+          <g id="St Asaph">
+            <circle cx="56.91" cy="96.65" r="1"/>
+            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwynedd">
+          <g id="Bangor">
+            <circle cx="50.69" cy="96.65" r="1"/>
+            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Riding of Yorkshire">
+          <g id="Kingston upon Hull">
+            <circle cx="78.4" cy="89.3" r="1"/>
+            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Yorkshire">
+          <g id="Wakefield">
+            <circle cx="70.49" cy="90.99" r="1"/>
+            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Leeds">
+            <circle cx="69.35" cy="89.3" r="1"/>
+            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bradford">
+            <circle cx="67.09" cy="89.3" r="1"/>
+            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lancashire">
+          <g id="Preston">
+            <circle cx="61.43" cy="89.3" r="1"/>
+            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lancaster">
+            <circle cx="61.43" cy="86.47" r="1"/>
+            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="North Yorkshire">
+          <g id="York">
+            <circle cx="72.75" cy="87.6" r="1"/>
+            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ripon">
+            <circle cx="69.92" cy="85.34" r="1"/>
+            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Durham">
+          <g id="Durham">
+            <circle cx="69.35" cy="78.55" r="1"/>
+            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Tyne and Wear">
+          <g id="Sunderland">
+            <circle cx="69.92" cy="76.29" r="1"/>
+            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newcastle upon Tyne">
+            <circle cx="68.79" cy="75.15" r="1"/>
+            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cumbria">
+          <g id="Carlisle">
+            <circle cx="60.3" cy="75.72" r="1"/>
+            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwent (county)">
+          <g id="Newport">
+            <circle cx="58.04" cy="115.88" r="1"/>
+            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Glamorgan">
+          <g id="Cardiff">
+            <circle cx="56.91" cy="117.01" r="1"/>
+            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Glamorgan">
+          <g id="Swansea">
+            <circle cx="52.95" cy="114.75" r="1"/>
+            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Stirling (council area)">
+          <g id="Stirling">
+            <circle cx="51.35" cy="61.00" r="1"/>
+            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Perth and Kinross">
+          <g id="Perth">
+            <circle cx="54.72" cy="58.42" r="1"/>
+            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Highland (council area)">
+          <g id="Inverness">
+            <circle cx="49.39" cy="44.2" r="1"/>
+            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Londonderry">
+          <g id="Derry">
+            <circle cx="27.11" cy="75.92" r="1"/>
+            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh / County Down">
+          <g id="Newry">
+            <circle cx="33.87" cy="86.58" r="1"/>
+            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh">
+          <g id="Armagh">
+            <circle cx="31.45" cy="84.59" r="1"/>
+            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Antrim / County Down">
+          <g id="Belfast">
+            <circle cx="36.41" cy="80.88" r="1"/>
+            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lisburn">
+            <circle cx="34.64" cy="81.71" r="1"/>
+            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/County - Map.html
+++ b/src/note_models/UK_Geog/templates/County - Map.html
@@ -164,385 +164,285 @@
           </g>
         </g>
         <g id="Cities">
-          <g id="Somerset">
-            <g id="Bath">
-              <circle cx="63.13" cy="119.28" r="1"/>
-              <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Wells">
-              <circle cx="60.87" cy="120.41" r="1"/>
-              <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Bath">
+            <circle cx="63.13" cy="119.28" r="1"/>
+            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cornwall">
-            <g id="Truro">
-              <circle cx="42.77" cy="132.85" r="1"/>
-              <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Truro">
+            <circle cx="42.77" cy="132.85" r="1"/>
+            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Decon">
-            <g id="Plymouth">
-              <circle cx="50.12" cy="130.59" r="1"/>
-              <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Exeter">
-              <circle cx="54.08" cy="127.2" r="1"/>
-              <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Plymouth">
+            <circle cx="50.12" cy="130.59" r="1"/>
+            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Wiltshire">
-            <g id="Salisbury">
-              <circle cx="67.66" cy="122.1" r="1"/>
-              <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Exeter">
+            <circle cx="54.08" cy="127.2" r="1"/>
+            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Hampshire">
-            <g id="Southampton">
-              <circle cx="71.5" cy="125" r="1"/>
-              <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Portsmouth">
-              <circle cx="73.5" cy="125.5" r="1"/>
-              <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Winchester">
-              <circle cx="72.3" cy="122.1" r="1"/>
-              <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wells">
+            <circle cx="60.87" cy="120.41" r="1"/>
+            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Sussex">
-            <g id="Chichester">
-              <circle cx="75.58" cy="124.93" r="1"/>
-              <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Salisbury">
+            <circle cx="67.66" cy="122.1" r="1"/>
+            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="East Sussex">
-            <g id="Brighton and Hove">
-              <circle cx="80.67" cy="124.93" r="1"/>
-              <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Southampton">
+            <circle cx="71.5" cy="125" r="1"/>
+            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Kent">
-            <g id="Canterbury">
-              <circle cx="89.94" cy="119.84" r="1"/>
-              <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Portsmouth">
+            <circle cx="73.5" cy="125.5" r="1"/>
+            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Greater London">
-            <g id="City of Westminster">
-              <circle cx="79.54" cy="117.01" r="1"/>
-              <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Chichester">
+            <circle cx="75.58" cy="124.93" r="1"/>
+            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Oxfordshire">
-            <g id="Oxford">
-              <circle cx="71.62" cy="113.62" r="1"/>
-              <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Winchester">
+            <circle cx="72.3" cy="122.1" r="1"/>
+            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Hertfordshire">
-            <g id="St Albans">
-              <circle cx="78.97" cy="113.62" r="1"/>
-              <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Brighton and Hove">
+            <circle cx="80.67" cy="124.93" r="1"/>
+            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Essex">
-            <g id="Chelmsford">
-              <circle cx="85.19" cy="113.62" r="1"/>
-              <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Colchester">
-              <circle cx="88.03" cy="112.06" r="1"/>
-              <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Southend-on-Sea">
-              <circle cx="86.81" cy="116.72" r="1"/>
-              <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Canterbury">
+            <circle cx="89.94" cy="119.84" r="1"/>
+            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Gloucestershire">
-            <g id="Gloucester">
-              <circle cx="64.26" cy="113.05" r="1"/>
-              <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="City of Westminster">
+            <circle cx="79.54" cy="117.01" r="1"/>
+            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Dyfed">
-            <g id="St Davids">
-              <circle cx="43.67" cy="112.49" r="1"/>
-              <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Southend-on-Sea">
+            <circle cx="86.81" cy="116.72" r="1"/>
+            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Herefordshire">
-            <g id="Hereford">
-              <circle cx="61.1" cy="110.79" r="1"/>
-              <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Oxford">
+            <circle cx="71.62" cy="113.62" r="1"/>
+            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Worcestershire">
-            <g id="Worcester">
-              <circle cx="64.83" cy="109.09" r="1"/>
-              <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="St Albans">
+            <circle cx="78.97" cy="113.62" r="1"/>
+            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cambridgeshire">
-            <g id="Cambridge">
-              <circle cx="81.23" cy="108.53" r="1"/>
-              <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Ely">
-              <circle cx="81.57" cy="106.27" r="1"/>
-              <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Peterborough">
-              <circle cx="78.97" cy="104" r="1"/>
-              <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Chelmsford">
+            <circle cx="85.19" cy="113.62" r="1"/>
+            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Midlands (county)">
-            <g id="Coventry">
-              <circle cx="69.35" cy="106.27" r="1"/>
-              <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Birmingham">
-              <circle cx="67.09" cy="105.14" r="1"/>
-              <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Wolverhampton">
-              <circle cx="65.39" cy="104" r="1"/>
-              <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Newport">
+            <circle cx="58.04" cy="115.88" r="1"/>
+            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g if="Norfolk">
-            <g id="Norwich">
-              <circle cx="89.72" cy="103.44" r="1"/>
-              <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Cardiff">
+            <circle cx="56.91" cy="117.01" r="1"/>
+            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Leicestershire">
-            <g id="Leicester">
-              <circle cx="72.52" cy="103.44" r="1"/>
-              <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Swansea">
+            <circle cx="52.95" cy="114.75" r="1"/>
+            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Staffordshire">
-            <g id="Lichfield">
-              <circle cx="67.88" cy="103.44" r="1"/>
-              <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Stoke-on-Trent">
-              <circle cx="65.39" cy="98.91" r="1"/>
-              <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Gloucester">
+            <circle cx="64.26" cy="113.05" r="1"/>
+            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Nottinghamshire">
-            <g id="Nottingham">
-              <circle cx="72.52" cy="100.04" r="1"/>
-              <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Colchester">
+            <circle cx="88.03" cy="112.06" r="1"/>
+            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Derbyshire">
-            <g id="Derby">
-              <circle cx="69.92" cy="99.48" r="1"/>
-              <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="St Davids">
+            <circle cx="43.67" cy="112.49" r="1"/>
+            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Lincolnshire">
-            <g id="Lincoln">
-              <circle cx="77.27" cy="97.78" r="1"/>
-              <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Milton Keynes">
+            <circle cx="75.50" cy="110.91" r="1"/>
+            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="South Yorkshire">
-            <g id="Doncaster">
-              <circle cx="72.613" cy="92.65" r="1"/>
-              <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Sheffield">
-              <circle cx="69.35" cy="94.39" r="1"/>
-              <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Hereford">
+            <circle cx="61.1" cy="110.79" r="1"/>
+            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Greater Manchester">
-            <g id="Manchester">
-              <circle cx="64.83" cy="93.26" r="1"/>
-              <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Salford">
-              <circle cx="63.92" cy="93.48" r="1"/>
-              <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Worcester">
+            <circle cx="64.83" cy="109.09" r="1"/>
+            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Merseyside">
-            <g id="Liverpool">
-              <circle cx="59.17" cy="94.39" r="1"/>
-              <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Cambridge">
+            <circle cx="81.23" cy="108.53" r="1"/>
+            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cheshire">
-            <g id="Chester">
-              <circle cx="60.3" cy="96.65" r="1"/>
-              <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Ely">
+            <circle cx="81.57" cy="106.27" r="1"/>
+            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Clwyd">
-            <g id="St Asaph">
-              <circle cx="56.91" cy="96.65" r="1"/>
-              <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Wrexham">
-              <circle cx="59.30" cy="97.79" r="1"/>
-              <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Coventry">
+            <circle cx="69.35" cy="106.27" r="1"/>
+            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Gwynedd">
-            <g id="Bangor">
-              <circle cx="50.69" cy="96.65" r="1"/>
-              <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Birmingham">
+            <circle cx="67.09" cy="105.14" r="1"/>
+            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="East Riding of Yorkshire">
-            <g id="Kingston upon Hull">
-              <circle cx="78.4" cy="89.3" r="1"/>
-              <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wolverhampton">
+            <circle cx="65.39" cy="104" r="1"/>
+            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Yorkshire">
-            <g id="Wakefield">
-              <circle cx="70.49" cy="90.99" r="1"/>
-              <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Leeds">
-              <circle cx="69.35" cy="89.3" r="1"/>
-              <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Bradford">
-              <circle cx="67.09" cy="89.3" r="1"/>
-              <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Norwich">
+            <circle cx="89.72" cy="103.44" r="1"/>
+            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Lancashire">
-            <g id="Preston">
-              <circle cx="61.43" cy="89.3" r="1"/>
-              <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Lancaster">
-              <circle cx="61.43" cy="86.47" r="1"/>
-              <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Peterborough">
+            <circle cx="78.97" cy="104" r="1"/>
+            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="North Yorkshire">
-            <g id="York">
-              <circle cx="72.75" cy="87.6" r="1"/>
-              <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Ripon">
-              <circle cx="69.92" cy="85.34" r="1"/>
-              <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Leicester">
+            <circle cx="72.52" cy="103.44" r="1"/>
+            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Durham">
-            <g id="Durham">
-              <circle cx="69.35" cy="78.55" r="1"/>
-              <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Lichfield">
+            <circle cx="67.88" cy="103.44" r="1"/>
+            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Tyne and Wear">
-            <g id="Sunderland">
-              <circle cx="69.92" cy="76.29" r="1"/>
-              <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Newcastle upon Tyne">
-              <circle cx="68.79" cy="75.15" r="1"/>
-              <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Nottingham">
+            <circle cx="72.52" cy="100.04" r="1"/>
+            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cumbria">
-            <g id="Carlisle">
-              <circle cx="60.3" cy="75.72" r="1"/>
-              <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Derby">
+            <circle cx="69.92" cy="99.48" r="1"/>
+            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Buckinghamshire">
-            <g id="Milton Keynes">
-              <circle cx="75.50" cy="110.91" r="1"/>
-              <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Stoke-on-Trent">
+            <circle cx="65.39" cy="98.91" r="1"/>
+            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Gwent (county)">
-            <g id="Newport">
-              <circle cx="58.04" cy="115.88" r="1"/>
-              <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Lincoln">
+            <circle cx="77.27" cy="97.78" r="1"/>
+            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="South Glamorgan">
-            <g id="Cardiff">
-              <circle cx="56.91" cy="117.01" r="1"/>
-              <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Sheffield">
+            <circle cx="69.35" cy="94.39" r="1"/>
+            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Glamorgan">
-            <g id="Swansea">
-              <circle cx="52.95" cy="114.75" r="1"/>
-              <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Doncaster">
+            <circle cx="72.613" cy="92.65" r="1"/>
+            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Stirling (council area)">
-            <g id="Stirling">
-              <circle cx="51.35" cy="61.00" r="1"/>
-              <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Manchester">
+            <circle cx="64.83" cy="93.26" r="1"/>
+            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Perth and Kinross">
-            <g id="Perth">
-              <circle cx="54.72" cy="58.42" r="1"/>
-              <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Salford">
+            <circle cx="63.92" cy="93.48" r="1"/>
+            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Highland (council area)">
-            <g id="Inverness">
-              <circle cx="49.39" cy="44.2" r="1"/>
-              <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Liverpool">
+            <circle cx="59.17" cy="94.39" r="1"/>
+            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Fife">
-            <g id="Dunfermline">
-              <circle cx="55.61" cy="61.85" r="1"/>
-              <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Chester">
+            <circle cx="60.3" cy="96.65" r="1"/>
+            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Down">
-            <g id="Bangor">
-              <circle cx="39.00" cy="79.86" r="1"/>
-              <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="St Asaph">
+            <circle cx="56.91" cy="96.65" r="1"/>
+            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Londonderry">
-            <g id="Derry">
-              <circle cx="27.11" cy="75.92" r="1"/>
-              <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wrexham">
+            <circle cx="59.30" cy="97.79" r="1"/>
+            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Armagh / County Down">
-            <g id="Newry">
-              <circle cx="33.87" cy="86.58" r="1"/>
-              <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Bangor, Gwynedd">
+            <circle cx="50.69" cy="96.65" r="1"/>
+            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Armagh">
-            <g id="Armagh">
-              <circle cx="31.45" cy="84.59" r="1"/>
-              <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Kingston upon Hull">
+            <circle cx="78.4" cy="89.3" r="1"/>
+            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Antrim / County Down">
-            <g id="Belfast">
-              <circle cx="36.41" cy="80.88" r="1"/>
-              <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Lisburn">
-              <circle cx="34.64" cy="81.71" r="1"/>
-              <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wakefield">
+            <circle cx="70.49" cy="90.99" r="1"/>
+            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Leeds">
+            <circle cx="69.35" cy="89.3" r="1"/>
+            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bradford">
+            <circle cx="67.09" cy="89.3" r="1"/>
+            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Preston">
+            <circle cx="61.43" cy="89.3" r="1"/>
+            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lancaster">
+            <circle cx="61.43" cy="86.47" r="1"/>
+            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="York">
+            <circle cx="72.75" cy="87.6" r="1"/>
+            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ripon">
+            <circle cx="69.92" cy="85.34" r="1"/>
+            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Durham">
+            <circle cx="69.35" cy="78.55" r="1"/>
+            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Sunderland">
+            <circle cx="69.92" cy="76.29" r="1"/>
+            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newcastle upon Tyne">
+            <circle cx="68.79" cy="75.15" r="1"/>
+            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Carlisle">
+            <circle cx="60.3" cy="75.72" r="1"/>
+            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Dunfermline">
+            <circle cx="55.61" cy="61.85" r="1"/>
+            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Stirling">
+            <circle cx="51.35" cy="61.00" r="1"/>
+            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Perth">
+            <circle cx="54.72" cy="58.42" r="1"/>
+            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Inverness">
+            <circle cx="49.39" cy="44.2" r="1"/>
+            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Derry">
+            <circle cx="27.11" cy="75.92" r="1"/>
+            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newry">
+            <circle cx="33.87" cy="86.58" r="1"/>
+            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bangor, County Down">
+            <circle cx="39.00" cy="79.86" r="1"/>
+            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Armagh">
+            <circle cx="31.45" cy="84.59" r="1"/>
+            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Belfast">
+            <circle cx="36.41" cy="80.88" r="1"/>
+            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lisburn">
+            <circle cx="34.64" cy="81.71" r="1"/>
+            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -736,385 +636,285 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Somerset">
-          <g id="Bath">
-            <circle cx="63.13" cy="119.28" r="1"/>
-            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wells">
-            <circle cx="60.87" cy="120.41" r="1"/>
-            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cornwall">
-          <g id="Truro">
-            <circle cx="42.77" cy="132.85" r="1"/>
-            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Decon">
-          <g id="Plymouth">
-            <circle cx="50.12" cy="130.59" r="1"/>
-            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Exeter">
-            <circle cx="54.08" cy="127.2" r="1"/>
-            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Wiltshire">
-          <g id="Salisbury">
-            <circle cx="67.66" cy="122.1" r="1"/>
-            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hampshire">
-          <g id="Southampton">
-            <circle cx="71.5" cy="125" r="1"/>
-            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Portsmouth">
-            <circle cx="73.5" cy="125.5" r="1"/>
-            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Winchester">
-            <circle cx="72.3" cy="122.1" r="1"/>
-            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Sussex">
-          <g id="Chichester">
-            <circle cx="75.58" cy="124.93" r="1"/>
-            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Sussex">
-          <g id="Brighton and Hove">
-            <circle cx="80.67" cy="124.93" r="1"/>
-            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Kent">
-          <g id="Canterbury">
-            <circle cx="89.94" cy="119.84" r="1"/>
-            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater London">
-          <g id="City of Westminster">
-            <circle cx="79.54" cy="117.01" r="1"/>
-            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Oxfordshire">
-          <g id="Oxford">
-            <circle cx="71.62" cy="113.62" r="1"/>
-            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hertfordshire">
-          <g id="St Albans">
-            <circle cx="78.97" cy="113.62" r="1"/>
-            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Essex">
-          <g id="Chelmsford">
-            <circle cx="85.19" cy="113.62" r="1"/>
-            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Colchester">
-            <circle cx="88.03" cy="112.06" r="1"/>
-            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Southend-on-Sea">
-            <circle cx="86.81" cy="116.72" r="1"/>
-            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gloucestershire">
-          <g id="Gloucester">
-            <circle cx="64.26" cy="113.05" r="1"/>
-            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Dyfed">
-          <g id="St Davids">
-            <circle cx="43.67" cy="112.49" r="1"/>
-            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Herefordshire">
-          <g id="Hereford">
-            <circle cx="61.1" cy="110.79" r="1"/>
-            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Worcestershire">
-          <g id="Worcester">
-            <circle cx="64.83" cy="109.09" r="1"/>
-            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cambridgeshire">
-          <g id="Cambridge">
-            <circle cx="81.23" cy="108.53" r="1"/>
-            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ely">
-            <circle cx="81.57" cy="106.27" r="1"/>
-            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Peterborough">
-            <circle cx="78.97" cy="104" r="1"/>
-            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Midlands (county)">
-          <g id="Coventry">
-            <circle cx="69.35" cy="106.27" r="1"/>
-            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Birmingham">
-            <circle cx="67.09" cy="105.14" r="1"/>
-            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wolverhampton">
-            <circle cx="65.39" cy="104" r="1"/>
-            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g if="Norfolk">
-          <g id="Norwich">
-            <circle cx="89.72" cy="103.44" r="1"/>
-            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Leicestershire">
-          <g id="Leicester">
-            <circle cx="72.52" cy="103.44" r="1"/>
-            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Staffordshire">
-          <g id="Lichfield">
-            <circle cx="67.88" cy="103.44" r="1"/>
-            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Stoke-on-Trent">
-            <circle cx="65.39" cy="98.91" r="1"/>
-            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Nottinghamshire">
-          <g id="Nottingham">
-            <circle cx="72.52" cy="100.04" r="1"/>
-            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Derbyshire">
-          <g id="Derby">
-            <circle cx="69.92" cy="99.48" r="1"/>
-            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lincolnshire">
-          <g id="Lincoln">
-            <circle cx="77.27" cy="97.78" r="1"/>
-            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Yorkshire">
-          <g id="Doncaster">
-            <circle cx="72.613" cy="92.65" r="1"/>
-            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Sheffield">
-            <circle cx="69.35" cy="94.39" r="1"/>
-            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater Manchester">
-          <g id="Manchester">
-            <circle cx="64.83" cy="93.26" r="1"/>
-            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Salford">
-            <circle cx="63.92" cy="93.48" r="1"/>
-            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Merseyside">
-          <g id="Liverpool">
-            <circle cx="59.17" cy="94.39" r="1"/>
-            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cheshire">
-          <g id="Chester">
-            <circle cx="60.3" cy="96.65" r="1"/>
-            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Clwyd">
-          <g id="St Asaph">
-            <circle cx="56.91" cy="96.65" r="1"/>
-            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wrexham">
-            <circle cx="59.30" cy="97.79" r="1"/>
-            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwynedd">
-          <g id="Bangor">
-            <circle cx="50.69" cy="96.65" r="1"/>
-            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Riding of Yorkshire">
-          <g id="Kingston upon Hull">
-            <circle cx="78.4" cy="89.3" r="1"/>
-            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Yorkshire">
-          <g id="Wakefield">
-            <circle cx="70.49" cy="90.99" r="1"/>
-            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Leeds">
-            <circle cx="69.35" cy="89.3" r="1"/>
-            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Bradford">
-            <circle cx="67.09" cy="89.3" r="1"/>
-            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lancashire">
-          <g id="Preston">
-            <circle cx="61.43" cy="89.3" r="1"/>
-            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lancaster">
-            <circle cx="61.43" cy="86.47" r="1"/>
-            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="North Yorkshire">
-          <g id="York">
-            <circle cx="72.75" cy="87.6" r="1"/>
-            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ripon">
-            <circle cx="69.92" cy="85.34" r="1"/>
-            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Durham">
-          <g id="Durham">
-            <circle cx="69.35" cy="78.55" r="1"/>
-            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Tyne and Wear">
-          <g id="Sunderland">
-            <circle cx="69.92" cy="76.29" r="1"/>
-            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newcastle upon Tyne">
-            <circle cx="68.79" cy="75.15" r="1"/>
-            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cumbria">
-          <g id="Carlisle">
-            <circle cx="60.3" cy="75.72" r="1"/>
-            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Buckinghamshire">
-          <g id="Milton Keynes">
-            <circle cx="75.50" cy="110.91" r="1"/>
-            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwent (county)">
-          <g id="Newport">
-            <circle cx="58.04" cy="115.88" r="1"/>
-            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Glamorgan">
-          <g id="Cardiff">
-            <circle cx="56.91" cy="117.01" r="1"/>
-            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Glamorgan">
-          <g id="Swansea">
-            <circle cx="52.95" cy="114.75" r="1"/>
-            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Stirling (council area)">
-          <g id="Stirling">
-            <circle cx="51.35" cy="61.00" r="1"/>
-            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Perth and Kinross">
-          <g id="Perth">
-            <circle cx="54.72" cy="58.42" r="1"/>
-            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Highland (council area)">
-          <g id="Inverness">
-            <circle cx="49.39" cy="44.2" r="1"/>
-            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Fife">
-          <g id="Dunfermline">
-            <circle cx="55.61" cy="61.85" r="1"/>
-            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Down">
-          <g id="Bangor">
-            <circle cx="39.00" cy="79.86" r="1"/>
-            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Londonderry">
-          <g id="Derry">
-            <circle cx="27.11" cy="75.92" r="1"/>
-            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh / County Down">
-          <g id="Newry">
-            <circle cx="33.87" cy="86.58" r="1"/>
-            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bangor, Gwynedd">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh">
-          <g id="Armagh">
-            <circle cx="31.45" cy="84.59" r="1"/>
-            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Antrim / County Down">
-          <g id="Belfast">
-            <circle cx="36.41" cy="80.88" r="1"/>
-            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lisburn">
-            <circle cx="34.64" cy="81.71" r="1"/>
-            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bangor, County Down">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/County - Region.html
+++ b/src/note_models/UK_Geog/templates/County - Region.html
@@ -313,6 +313,14 @@
             <circle cx="85.19" cy="113.62" r="1"/>
             <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
+          <g id="Colchester">
+            <circle cx="88.03" cy="112.06" r="1"/>
+            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Southend-on-Sea">
+            <circle cx="86.81" cy="116.72" r="1"/>
+            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
         <g id="Gloucestershire">
           <g id="Gloucester">
@@ -407,6 +415,10 @@
           </g>
         </g>
         <g id="South Yorkshire">
+          <g id="Doncaster">
+            <circle cx="72.613" cy="92.65" r="1"/>
+            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
           <g id="Sheffield">
             <circle cx="69.35" cy="94.39" r="1"/>
             <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -438,6 +450,10 @@
           <g id="St Asaph">
             <circle cx="56.91" cy="96.65" r="1"/>
             <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wrexham">
+            <circle cx="59.30" cy="97.79" r="1"/>
+            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="Gwynedd">
@@ -508,6 +524,12 @@
             <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
+        <g id="Buckinghamshire">
+          <g id="Milton Keynes">
+            <circle cx="75.50" cy="110.91" r="1"/>
+            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
         <g id="Gwent (county)">
           <g id="Newport">
             <circle cx="58.04" cy="115.88" r="1"/>
@@ -542,6 +564,18 @@
           <g id="Inverness">
             <circle cx="49.39" cy="44.2" r="1"/>
             <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="Fife">
+          <g id="Dunfermline">
+            <circle cx="55.61" cy="61.85" r="1"/>
+            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="County Down">
+          <g id="Bangor">
+            <circle cx="39.00" cy="79.86" r="1"/>
+            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="County Londonderry">

--- a/src/note_models/UK_Geog/templates/County - Region.html
+++ b/src/note_models/UK_Geog/templates/County - Region.html
@@ -226,385 +226,285 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Somerset">
-          <g id="Bath">
-            <circle cx="63.13" cy="119.28" r="1"/>
-            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wells">
-            <circle cx="60.87" cy="120.41" r="1"/>
-            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cornwall">
-          <g id="Truro">
-            <circle cx="42.77" cy="132.85" r="1"/>
-            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Decon">
-          <g id="Plymouth">
-            <circle cx="50.12" cy="130.59" r="1"/>
-            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Exeter">
-            <circle cx="54.08" cy="127.2" r="1"/>
-            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Wiltshire">
-          <g id="Salisbury">
-            <circle cx="67.66" cy="122.1" r="1"/>
-            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hampshire">
-          <g id="Southampton">
-            <circle cx="71.5" cy="125" r="1"/>
-            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Portsmouth">
-            <circle cx="73.5" cy="125.5" r="1"/>
-            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Winchester">
-            <circle cx="72.3" cy="122.1" r="1"/>
-            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Sussex">
-          <g id="Chichester">
-            <circle cx="75.58" cy="124.93" r="1"/>
-            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Sussex">
-          <g id="Brighton and Hove">
-            <circle cx="80.67" cy="124.93" r="1"/>
-            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Kent">
-          <g id="Canterbury">
-            <circle cx="89.94" cy="119.84" r="1"/>
-            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater London">
-          <g id="City of Westminster">
-            <circle cx="79.54" cy="117.01" r="1"/>
-            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Oxfordshire">
-          <g id="Oxford">
-            <circle cx="71.62" cy="113.62" r="1"/>
-            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hertfordshire">
-          <g id="St Albans">
-            <circle cx="78.97" cy="113.62" r="1"/>
-            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Essex">
-          <g id="Chelmsford">
-            <circle cx="85.19" cy="113.62" r="1"/>
-            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Colchester">
-            <circle cx="88.03" cy="112.06" r="1"/>
-            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Southend-on-Sea">
-            <circle cx="86.81" cy="116.72" r="1"/>
-            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gloucestershire">
-          <g id="Gloucester">
-            <circle cx="64.26" cy="113.05" r="1"/>
-            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Dyfed">
-          <g id="St Davids">
-            <circle cx="43.67" cy="112.49" r="1"/>
-            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Herefordshire">
-          <g id="Hereford">
-            <circle cx="61.1" cy="110.79" r="1"/>
-            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Worcestershire">
-          <g id="Worcester">
-            <circle cx="64.83" cy="109.09" r="1"/>
-            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cambridgeshire">
-          <g id="Cambridge">
-            <circle cx="81.23" cy="108.53" r="1"/>
-            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ely">
-            <circle cx="81.57" cy="106.27" r="1"/>
-            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Peterborough">
-            <circle cx="78.97" cy="104" r="1"/>
-            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Midlands (county)">
-          <g id="Coventry">
-            <circle cx="69.35" cy="106.27" r="1"/>
-            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Birmingham">
-            <circle cx="67.09" cy="105.14" r="1"/>
-            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wolverhampton">
-            <circle cx="65.39" cy="104" r="1"/>
-            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g if="Norfolk">
-          <g id="Norwich">
-            <circle cx="89.72" cy="103.44" r="1"/>
-            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Leicestershire">
-          <g id="Leicester">
-            <circle cx="72.52" cy="103.44" r="1"/>
-            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Staffordshire">
-          <g id="Lichfield">
-            <circle cx="67.88" cy="103.44" r="1"/>
-            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Stoke-on-Trent">
-            <circle cx="65.39" cy="98.91" r="1"/>
-            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Nottinghamshire">
-          <g id="Nottingham">
-            <circle cx="72.52" cy="100.04" r="1"/>
-            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Derbyshire">
-          <g id="Derby">
-            <circle cx="69.92" cy="99.48" r="1"/>
-            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lincolnshire">
-          <g id="Lincoln">
-            <circle cx="77.27" cy="97.78" r="1"/>
-            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Yorkshire">
-          <g id="Doncaster">
-            <circle cx="72.613" cy="92.65" r="1"/>
-            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Sheffield">
-            <circle cx="69.35" cy="94.39" r="1"/>
-            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater Manchester">
-          <g id="Manchester">
-            <circle cx="64.83" cy="93.26" r="1"/>
-            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Salford">
-            <circle cx="63.92" cy="93.48" r="1"/>
-            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Merseyside">
-          <g id="Liverpool">
-            <circle cx="59.17" cy="94.39" r="1"/>
-            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cheshire">
-          <g id="Chester">
-            <circle cx="60.3" cy="96.65" r="1"/>
-            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Clwyd">
-          <g id="St Asaph">
-            <circle cx="56.91" cy="96.65" r="1"/>
-            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wrexham">
-            <circle cx="59.30" cy="97.79" r="1"/>
-            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwynedd">
-          <g id="Bangor">
-            <circle cx="50.69" cy="96.65" r="1"/>
-            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Riding of Yorkshire">
-          <g id="Kingston upon Hull">
-            <circle cx="78.4" cy="89.3" r="1"/>
-            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Yorkshire">
-          <g id="Wakefield">
-            <circle cx="70.49" cy="90.99" r="1"/>
-            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Leeds">
-            <circle cx="69.35" cy="89.3" r="1"/>
-            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Bradford">
-            <circle cx="67.09" cy="89.3" r="1"/>
-            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lancashire">
-          <g id="Preston">
-            <circle cx="61.43" cy="89.3" r="1"/>
-            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lancaster">
-            <circle cx="61.43" cy="86.47" r="1"/>
-            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="North Yorkshire">
-          <g id="York">
-            <circle cx="72.75" cy="87.6" r="1"/>
-            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ripon">
-            <circle cx="69.92" cy="85.34" r="1"/>
-            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Durham">
-          <g id="Durham">
-            <circle cx="69.35" cy="78.55" r="1"/>
-            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Tyne and Wear">
-          <g id="Sunderland">
-            <circle cx="69.92" cy="76.29" r="1"/>
-            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newcastle upon Tyne">
-            <circle cx="68.79" cy="75.15" r="1"/>
-            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cumbria">
-          <g id="Carlisle">
-            <circle cx="60.3" cy="75.72" r="1"/>
-            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Buckinghamshire">
-          <g id="Milton Keynes">
-            <circle cx="75.50" cy="110.91" r="1"/>
-            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwent (county)">
-          <g id="Newport">
-            <circle cx="58.04" cy="115.88" r="1"/>
-            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Glamorgan">
-          <g id="Cardiff">
-            <circle cx="56.91" cy="117.01" r="1"/>
-            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Glamorgan">
-          <g id="Swansea">
-            <circle cx="52.95" cy="114.75" r="1"/>
-            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Stirling (council area)">
-          <g id="Stirling">
-            <circle cx="51.35" cy="61.00" r="1"/>
-            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Perth and Kinross">
-          <g id="Perth">
-            <circle cx="54.72" cy="58.42" r="1"/>
-            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Highland (council area)">
-          <g id="Inverness">
-            <circle cx="49.39" cy="44.2" r="1"/>
-            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Fife">
-          <g id="Dunfermline">
-            <circle cx="55.61" cy="61.85" r="1"/>
-            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Down">
-          <g id="Bangor">
-            <circle cx="39.00" cy="79.86" r="1"/>
-            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Londonderry">
-          <g id="Derry">
-            <circle cx="27.11" cy="75.92" r="1"/>
-            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh / County Down">
-          <g id="Newry">
-            <circle cx="33.87" cy="86.58" r="1"/>
-            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bangor, Gwynedd">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh">
-          <g id="Armagh">
-            <circle cx="31.45" cy="84.59" r="1"/>
-            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Antrim / County Down">
-          <g id="Belfast">
-            <circle cx="36.41" cy="80.88" r="1"/>
-            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lisburn">
-            <circle cx="34.64" cy="81.71" r="1"/>
-            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bangor, County Down">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/County - Region.html
+++ b/src/note_models/UK_Geog/templates/County - Region.html
@@ -226,257 +226,351 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Somerset">
+          <g id="Bath">
+            <circle cx="63.13" cy="119.28" r="1"/>
+            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wells">
+            <circle cx="60.87" cy="120.41" r="1"/>
+            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cornwall">
+          <g id="Truro">
+            <circle cx="42.77" cy="132.85" r="1"/>
+            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Decon">
+          <g id="Plymouth">
+            <circle cx="50.12" cy="130.59" r="1"/>
+            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Exeter">
+            <circle cx="54.08" cy="127.2" r="1"/>
+            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Wiltshire">
+          <g id="Salisbury">
+            <circle cx="67.66" cy="122.1" r="1"/>
+            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hampshire">
+          <g id="Southampton">
+            <circle cx="71.5" cy="125" r="1"/>
+            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Portsmouth">
+            <circle cx="73.5" cy="125.5" r="1"/>
+            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Winchester">
+            <circle cx="72.3" cy="122.1" r="1"/>
+            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Sussex">
+          <g id="Chichester">
+            <circle cx="75.58" cy="124.93" r="1"/>
+            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Sussex">
+          <g id="Brighton and Hove">
+            <circle cx="80.67" cy="124.93" r="1"/>
+            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Kent">
+          <g id="Canterbury">
+            <circle cx="89.94" cy="119.84" r="1"/>
+            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater London">
+          <g id="City of Westminster">
+            <circle cx="79.54" cy="117.01" r="1"/>
+            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Oxfordshire">
+          <g id="Oxford">
+            <circle cx="71.62" cy="113.62" r="1"/>
+            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hertfordshire">
+          <g id="St Albans">
+            <circle cx="78.97" cy="113.62" r="1"/>
+            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Essex">
+          <g id="Chelmsford">
+            <circle cx="85.19" cy="113.62" r="1"/>
+            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gloucestershire">
+          <g id="Gloucester">
+            <circle cx="64.26" cy="113.05" r="1"/>
+            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Dyfed">
+          <g id="St Davids">
+            <circle cx="43.67" cy="112.49" r="1"/>
+            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Herefordshire">
+          <g id="Hereford">
+            <circle cx="61.1" cy="110.79" r="1"/>
+            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Worcestershire">
+          <g id="Worcester">
+            <circle cx="64.83" cy="109.09" r="1"/>
+            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cambridgeshire">
+          <g id="Cambridge">
+            <circle cx="81.23" cy="108.53" r="1"/>
+            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ely">
+            <circle cx="81.57" cy="106.27" r="1"/>
+            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Peterborough">
+            <circle cx="78.97" cy="104" r="1"/>
+            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Midlands (county)">
+          <g id="Coventry">
+            <circle cx="69.35" cy="106.27" r="1"/>
+            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Birmingham">
+            <circle cx="67.09" cy="105.14" r="1"/>
+            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wolverhampton">
+            <circle cx="65.39" cy="104" r="1"/>
+            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g if="Norfolk">
+          <g id="Norwich">
+            <circle cx="89.72" cy="103.44" r="1"/>
+            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Leicestershire">
+          <g id="Leicester">
+            <circle cx="72.52" cy="103.44" r="1"/>
+            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Staffordshire">
+          <g id="Lichfield">
+            <circle cx="67.88" cy="103.44" r="1"/>
+            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Stoke-on-Trent">
+            <circle cx="65.39" cy="98.91" r="1"/>
+            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Nottinghamshire">
+          <g id="Nottingham">
+            <circle cx="72.52" cy="100.04" r="1"/>
+            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Derbyshire">
+          <g id="Derby">
+            <circle cx="69.92" cy="99.48" r="1"/>
+            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lincolnshire">
+          <g id="Lincoln">
+            <circle cx="77.27" cy="97.78" r="1"/>
+            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Yorkshire">
+          <g id="Sheffield">
+            <circle cx="69.35" cy="94.39" r="1"/>
+            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater Manchester">
+          <g id="Manchester">
+            <circle cx="64.83" cy="93.26" r="1"/>
+            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Salford">
+            <circle cx="63.92" cy="93.48" r="1"/>
+            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Merseyside">
+          <g id="Liverpool">
+            <circle cx="59.17" cy="94.39" r="1"/>
+            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cheshire">
+          <g id="Chester">
+            <circle cx="60.3" cy="96.65" r="1"/>
+            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Clwyd">
+          <g id="St Asaph">
+            <circle cx="56.91" cy="96.65" r="1"/>
+            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwynedd">
+          <g id="Bangor">
+            <circle cx="50.69" cy="96.65" r="1"/>
+            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Riding of Yorkshire">
+          <g id="Kingston upon Hull">
+            <circle cx="78.4" cy="89.3" r="1"/>
+            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Yorkshire">
+          <g id="Wakefield">
+            <circle cx="70.49" cy="90.99" r="1"/>
+            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Leeds">
+            <circle cx="69.35" cy="89.3" r="1"/>
+            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bradford">
+            <circle cx="67.09" cy="89.3" r="1"/>
+            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lancashire">
+          <g id="Preston">
+            <circle cx="61.43" cy="89.3" r="1"/>
+            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lancaster">
+            <circle cx="61.43" cy="86.47" r="1"/>
+            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="North Yorkshire">
+          <g id="York">
+            <circle cx="72.75" cy="87.6" r="1"/>
+            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ripon">
+            <circle cx="69.92" cy="85.34" r="1"/>
+            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Durham">
+          <g id="Durham">
+            <circle cx="69.35" cy="78.55" r="1"/>
+            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Tyne and Wear">
+          <g id="Sunderland">
+            <circle cx="69.92" cy="76.29" r="1"/>
+            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newcastle upon Tyne">
+            <circle cx="68.79" cy="75.15" r="1"/>
+            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cumbria">
+          <g id="Carlisle">
+            <circle cx="60.3" cy="75.72" r="1"/>
+            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwent (county)">
+          <g id="Newport">
+            <circle cx="58.04" cy="115.88" r="1"/>
+            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Glamorgan">
+          <g id="Cardiff">
+            <circle cx="56.91" cy="117.01" r="1"/>
+            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Glamorgan">
+          <g id="Swansea">
+            <circle cx="52.95" cy="114.75" r="1"/>
+            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Stirling (council area)">
+          <g id="Stirling">
+            <circle cx="51.35" cy="61.00" r="1"/>
+            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Perth and Kinross">
+          <g id="Perth">
+            <circle cx="54.72" cy="58.42" r="1"/>
+            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Highland (council area)">
+          <g id="Inverness">
+            <circle cx="49.39" cy="44.2" r="1"/>
+            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Londonderry">
+          <g id="Derry">
+            <circle cx="27.11" cy="75.92" r="1"/>
+            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh / County Down">
+          <g id="Newry">
+            <circle cx="33.87" cy="86.58" r="1"/>
+            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh">
+          <g id="Armagh">
+            <circle cx="31.45" cy="84.59" r="1"/>
+            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Antrim / County Down">
+          <g id="Belfast">
+            <circle cx="36.41" cy="80.88" r="1"/>
+            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lisburn">
+            <circle cx="34.64" cy="81.71" r="1"/>
+            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/Map - BoW.html
+++ b/src/note_models/UK_Geog/templates/Map - BoW.html
@@ -252,6 +252,14 @@
             <circle cx="85.19" cy="113.62" r="1"/>
             <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
+          <g id="Colchester">
+            <circle cx="88.03" cy="112.06" r="1"/>
+            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Southend-on-Sea">
+            <circle cx="86.81" cy="116.72" r="1"/>
+            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
         <g id="Gloucestershire">
           <g id="Gloucester">
@@ -346,6 +354,10 @@
           </g>
         </g>
         <g id="South Yorkshire">
+          <g id="Doncaster">
+            <circle cx="72.613" cy="92.65" r="1"/>
+            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
           <g id="Sheffield">
             <circle cx="69.35" cy="94.39" r="1"/>
             <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -377,6 +389,10 @@
           <g id="St Asaph">
             <circle cx="56.91" cy="96.65" r="1"/>
             <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wrexham">
+            <circle cx="59.30" cy="97.79" r="1"/>
+            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="Gwynedd">
@@ -447,6 +463,12 @@
             <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
+        <g id="Buckinghamshire">
+          <g id="Milton Keynes">
+            <circle cx="75.50" cy="110.91" r="1"/>
+            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
         <g id="Gwent (county)">
           <g id="Newport">
             <circle cx="58.04" cy="115.88" r="1"/>
@@ -481,6 +503,18 @@
           <g id="Inverness">
             <circle cx="49.39" cy="44.2" r="1"/>
             <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="Fife">
+          <g id="Dunfermline">
+            <circle cx="55.61" cy="61.85" r="1"/>
+            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="County Down">
+          <g id="Bangor">
+            <circle cx="39.00" cy="79.86" r="1"/>
+            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="County Londonderry">
@@ -773,6 +807,14 @@
           <circle cx="85.19" cy="113.62" r="1"/>
           <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
       <g id="Gloucestershire">
         <g id="Gloucester">
@@ -867,6 +909,10 @@
         </g>
       </g>
       <g id="South Yorkshire">
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
         <g id="Sheffield">
           <circle cx="69.35" cy="94.39" r="1"/>
           <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -898,6 +944,10 @@
         <g id="St Asaph">
           <circle cx="56.91" cy="96.65" r="1"/>
           <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <g id="Gwynedd">
@@ -968,6 +1018,12 @@
           <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
+      <g id="Buckinghamshire">
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
       <g id="Gwent (county)">
         <g id="Newport">
           <circle cx="58.04" cy="115.88" r="1"/>
@@ -1002,6 +1058,18 @@
         <g id="Inverness">
           <circle cx="49.39" cy="44.2" r="1"/>
           <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
+      <g id="Fife">
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
+      <g id="County Down">
+        <g id="Bangor">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <g id="County Londonderry">

--- a/src/note_models/UK_Geog/templates/Map - BoW.html
+++ b/src/note_models/UK_Geog/templates/Map - BoW.html
@@ -165,257 +165,351 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Somerset">
+          <g id="Bath">
+            <circle cx="63.13" cy="119.28" r="1"/>
+            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wells">
+            <circle cx="60.87" cy="120.41" r="1"/>
+            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cornwall">
+          <g id="Truro">
+            <circle cx="42.77" cy="132.85" r="1"/>
+            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Decon">
+          <g id="Plymouth">
+            <circle cx="50.12" cy="130.59" r="1"/>
+            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Exeter">
+            <circle cx="54.08" cy="127.2" r="1"/>
+            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Wiltshire">
+          <g id="Salisbury">
+            <circle cx="67.66" cy="122.1" r="1"/>
+            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hampshire">
+          <g id="Southampton">
+            <circle cx="71.5" cy="125" r="1"/>
+            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Portsmouth">
+            <circle cx="73.5" cy="125.5" r="1"/>
+            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Winchester">
+            <circle cx="72.3" cy="122.1" r="1"/>
+            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Sussex">
+          <g id="Chichester">
+            <circle cx="75.58" cy="124.93" r="1"/>
+            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Sussex">
+          <g id="Brighton and Hove">
+            <circle cx="80.67" cy="124.93" r="1"/>
+            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Kent">
+          <g id="Canterbury">
+            <circle cx="89.94" cy="119.84" r="1"/>
+            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater London">
+          <g id="City of Westminster">
+            <circle cx="79.54" cy="117.01" r="1"/>
+            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Oxfordshire">
+          <g id="Oxford">
+            <circle cx="71.62" cy="113.62" r="1"/>
+            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hertfordshire">
+          <g id="St Albans">
+            <circle cx="78.97" cy="113.62" r="1"/>
+            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Essex">
+          <g id="Chelmsford">
+            <circle cx="85.19" cy="113.62" r="1"/>
+            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gloucestershire">
+          <g id="Gloucester">
+            <circle cx="64.26" cy="113.05" r="1"/>
+            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Dyfed">
+          <g id="St Davids">
+            <circle cx="43.67" cy="112.49" r="1"/>
+            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Herefordshire">
+          <g id="Hereford">
+            <circle cx="61.1" cy="110.79" r="1"/>
+            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Worcestershire">
+          <g id="Worcester">
+            <circle cx="64.83" cy="109.09" r="1"/>
+            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cambridgeshire">
+          <g id="Cambridge">
+            <circle cx="81.23" cy="108.53" r="1"/>
+            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ely">
+            <circle cx="81.57" cy="106.27" r="1"/>
+            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Peterborough">
+            <circle cx="78.97" cy="104" r="1"/>
+            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Midlands (county)">
+          <g id="Coventry">
+            <circle cx="69.35" cy="106.27" r="1"/>
+            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Birmingham">
+            <circle cx="67.09" cy="105.14" r="1"/>
+            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wolverhampton">
+            <circle cx="65.39" cy="104" r="1"/>
+            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g if="Norfolk">
+          <g id="Norwich">
+            <circle cx="89.72" cy="103.44" r="1"/>
+            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Leicestershire">
+          <g id="Leicester">
+            <circle cx="72.52" cy="103.44" r="1"/>
+            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Staffordshire">
+          <g id="Lichfield">
+            <circle cx="67.88" cy="103.44" r="1"/>
+            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Stoke-on-Trent">
+            <circle cx="65.39" cy="98.91" r="1"/>
+            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Nottinghamshire">
+          <g id="Nottingham">
+            <circle cx="72.52" cy="100.04" r="1"/>
+            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Derbyshire">
+          <g id="Derby">
+            <circle cx="69.92" cy="99.48" r="1"/>
+            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lincolnshire">
+          <g id="Lincoln">
+            <circle cx="77.27" cy="97.78" r="1"/>
+            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Yorkshire">
+          <g id="Sheffield">
+            <circle cx="69.35" cy="94.39" r="1"/>
+            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater Manchester">
+          <g id="Manchester">
+            <circle cx="64.83" cy="93.26" r="1"/>
+            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Salford">
+            <circle cx="63.92" cy="93.48" r="1"/>
+            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Merseyside">
+          <g id="Liverpool">
+            <circle cx="59.17" cy="94.39" r="1"/>
+            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cheshire">
+          <g id="Chester">
+            <circle cx="60.3" cy="96.65" r="1"/>
+            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Clwyd">
+          <g id="St Asaph">
+            <circle cx="56.91" cy="96.65" r="1"/>
+            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwynedd">
+          <g id="Bangor">
+            <circle cx="50.69" cy="96.65" r="1"/>
+            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Riding of Yorkshire">
+          <g id="Kingston upon Hull">
+            <circle cx="78.4" cy="89.3" r="1"/>
+            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Yorkshire">
+          <g id="Wakefield">
+            <circle cx="70.49" cy="90.99" r="1"/>
+            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Leeds">
+            <circle cx="69.35" cy="89.3" r="1"/>
+            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bradford">
+            <circle cx="67.09" cy="89.3" r="1"/>
+            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lancashire">
+          <g id="Preston">
+            <circle cx="61.43" cy="89.3" r="1"/>
+            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lancaster">
+            <circle cx="61.43" cy="86.47" r="1"/>
+            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="North Yorkshire">
+          <g id="York">
+            <circle cx="72.75" cy="87.6" r="1"/>
+            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ripon">
+            <circle cx="69.92" cy="85.34" r="1"/>
+            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Durham">
+          <g id="Durham">
+            <circle cx="69.35" cy="78.55" r="1"/>
+            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Tyne and Wear">
+          <g id="Sunderland">
+            <circle cx="69.92" cy="76.29" r="1"/>
+            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newcastle upon Tyne">
+            <circle cx="68.79" cy="75.15" r="1"/>
+            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cumbria">
+          <g id="Carlisle">
+            <circle cx="60.3" cy="75.72" r="1"/>
+            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwent (county)">
+          <g id="Newport">
+            <circle cx="58.04" cy="115.88" r="1"/>
+            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Glamorgan">
+          <g id="Cardiff">
+            <circle cx="56.91" cy="117.01" r="1"/>
+            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Glamorgan">
+          <g id="Swansea">
+            <circle cx="52.95" cy="114.75" r="1"/>
+            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Stirling (council area)">
+          <g id="Stirling">
+            <circle cx="51.35" cy="61.00" r="1"/>
+            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Perth and Kinross">
+          <g id="Perth">
+            <circle cx="54.72" cy="58.42" r="1"/>
+            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Highland (council area)">
+          <g id="Inverness">
+            <circle cx="49.39" cy="44.2" r="1"/>
+            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Londonderry">
+          <g id="Derry">
+            <circle cx="27.11" cy="75.92" r="1"/>
+            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh / County Down">
+          <g id="Newry">
+            <circle cx="33.87" cy="86.58" r="1"/>
+            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh">
+          <g id="Armagh">
+            <circle cx="31.45" cy="84.59" r="1"/>
+            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Antrim / County Down">
+          <g id="Belfast">
+            <circle cx="36.41" cy="80.88" r="1"/>
+            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lisburn">
+            <circle cx="34.64" cy="81.71" r="1"/>
+            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -592,257 +686,351 @@
       </g>
     </g>
     <g id="Cities">
-      <g id="Bath">
-        <circle cx="63.13" cy="119.28" r="1"/>
-        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Somerset">
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Truro">
-        <circle cx="42.77" cy="132.85" r="1"/>
-        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cornwall">
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Plymouth">
-        <circle cx="50.12" cy="130.59" r="1"/>
-        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Decon">
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Exeter">
-        <circle cx="54.08" cy="127.2" r="1"/>
-        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Wiltshire">
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wells">
-        <circle cx="60.87" cy="120.41" r="1"/>
-        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Hampshire">
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Salisbury">
-        <circle cx="67.66" cy="122.1" r="1"/>
-        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Sussex">
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Southampton">
-        <circle cx="71.5" cy="125" r="1"/>
-        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="East Sussex">
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Portsmouth">
-        <circle cx="73.5" cy="125.5" r="1"/>
-        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Kent">
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chichester">
-        <circle cx="75.58" cy="124.93" r="1"/>
-        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Greater London">
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Winchester">
-        <circle cx="72.3" cy="122.1" r="1"/>
-        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Oxfordshire">
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Brighton and Hove">
-        <circle cx="80.67" cy="124.93" r="1"/>
-        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Hertfordshire">
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Canterbury">
-        <circle cx="89.94" cy="119.84" r="1"/>
-        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Essex">
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="City of Westminster">
-        <circle cx="79.54" cy="117.01" r="1"/>
-        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gloucestershire">
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Oxford">
-        <circle cx="71.62" cy="113.62" r="1"/>
-        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Dyfed">
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Albans">
-        <circle cx="78.97" cy="113.62" r="1"/>
-        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Herefordshire">
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chelmsford">
-        <circle cx="85.19" cy="113.62" r="1"/>
-        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Worcestershire">
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Newport">
-        <circle cx="58.04" cy="115.88" r="1"/>
-        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cambridgeshire">
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Cardiff">
-        <circle cx="56.91" cy="117.01" r="1"/>
-        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Midlands (county)">
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Swansea">
-        <circle cx="52.95" cy="114.75" r="1"/>
-        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g if="Norfolk">
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Gloucester">
-        <circle cx="64.26" cy="113.05" r="1"/>
-        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Leicestershire">
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Davids">
-        <circle cx="43.67" cy="112.49" r="1"/>
-        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Staffordshire">
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Hereford">
-        <circle cx="61.1" cy="110.79" r="1"/>
-        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Nottinghamshire">
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Worcester">
-        <circle cx="64.83" cy="109.09" r="1"/>
-        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Derbyshire">
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Cambridge">
-        <circle cx="81.23" cy="108.53" r="1"/>
-        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Lincolnshire">
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Ely">
-        <circle cx="81.57" cy="106.27" r="1"/>
-        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="South Yorkshire">
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Coventry">
-        <circle cx="69.35" cy="106.27" r="1"/>
-        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Greater Manchester">
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Birmingham">
-        <circle cx="67.09" cy="105.14" r="1"/>
-        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Merseyside">
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wolverhampton">
-        <circle cx="65.39" cy="104" r="1"/>
-        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cheshire">
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Norwich">
-        <circle cx="89.72" cy="103.44" r="1"/>
-        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Clwyd">
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Peterborough">
-        <circle cx="78.97" cy="104" r="1"/>
-        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gwynedd">
+        <g id="Bangor">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Leicester">
-        <circle cx="72.52" cy="103.44" r="1"/>
-        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="East Riding of Yorkshire">
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Lichfield">
-        <circle cx="67.88" cy="103.44" r="1"/>
-        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Yorkshire">
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Nottingham">
-        <circle cx="72.52" cy="100.04" r="1"/>
-        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Lancashire">
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Derby">
-        <circle cx="69.92" cy="99.48" r="1"/>
-        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="North Yorkshire">
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Stoke-on-Trent">
-        <circle cx="65.39" cy="98.91" r="1"/>
-        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Durham">
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Lincoln">
-        <circle cx="77.27" cy="97.78" r="1"/>
-        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Tyne and Wear">
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Sheffield">
-        <circle cx="69.35" cy="94.39" r="1"/>
-        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cumbria">
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Manchester">
-        <circle cx="64.83" cy="93.26" r="1"/>
-        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gwent (county)">
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Salford">
-        <circle cx="63.92" cy="93.48" r="1"/>
-        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="South Glamorgan">
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Liverpool">
-        <circle cx="59.17" cy="94.39" r="1"/>
-        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Glamorgan">
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chester">
-        <circle cx="60.3" cy="96.65" r="1"/>
-        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Stirling (council area)">
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Asaph">
-        <circle cx="56.91" cy="96.65" r="1"/>
-        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Perth and Kinross">
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Bangor">
-        <circle cx="50.69" cy="96.65" r="1"/>
-        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Highland (council area)">
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Kingston upon Hull">
-        <circle cx="78.4" cy="89.3" r="1"/>
-        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Londonderry">
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wakefield">
-        <circle cx="70.49" cy="90.99" r="1"/>
-        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Armagh / County Down">
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Leeds">
-        <circle cx="69.35" cy="89.3" r="1"/>
-        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Armagh">
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Bradford">
-        <circle cx="67.09" cy="89.3" r="1"/>
-        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Preston">
-        <circle cx="61.43" cy="89.3" r="1"/>
-        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lancaster">
-        <circle cx="61.43" cy="86.47" r="1"/>
-        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="York">
-        <circle cx="72.75" cy="87.6" r="1"/>
-        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Ripon">
-        <circle cx="69.92" cy="85.34" r="1"/>
-        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Durham">
-        <circle cx="69.35" cy="78.55" r="1"/>
-        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Sunderland">
-        <circle cx="69.92" cy="76.29" r="1"/>
-        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newcastle upon Tyne">
-        <circle cx="68.79" cy="75.15" r="1"/>
-        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Carlisle">
-        <circle cx="60.3" cy="75.72" r="1"/>
-        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Stirling">
-        <circle cx="51.35" cy="61.00" r="1"/>
-        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Perth">
-        <circle cx="54.72" cy="58.42" r="1"/>
-        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Inverness">
-        <circle cx="49.39" cy="44.2" r="1"/>
-        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Derry">
-        <circle cx="27.11" cy="75.92" r="1"/>
-        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newry">
-        <circle cx="33.87" cy="86.58" r="1"/>
-        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Armagh">
-        <circle cx="31.45" cy="84.59" r="1"/>
-        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Belfast">
-        <circle cx="36.41" cy="80.88" r="1"/>
-        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lisburn">
-        <circle cx="34.64" cy="81.71" r="1"/>
-        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Antrim / County Down">
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
     </g>
     <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/Map - BoW.html
+++ b/src/note_models/UK_Geog/templates/Map - BoW.html
@@ -165,385 +165,285 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Somerset">
-          <g id="Bath">
-            <circle cx="63.13" cy="119.28" r="1"/>
-            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wells">
-            <circle cx="60.87" cy="120.41" r="1"/>
-            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cornwall">
-          <g id="Truro">
-            <circle cx="42.77" cy="132.85" r="1"/>
-            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Decon">
-          <g id="Plymouth">
-            <circle cx="50.12" cy="130.59" r="1"/>
-            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Exeter">
-            <circle cx="54.08" cy="127.2" r="1"/>
-            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Wiltshire">
-          <g id="Salisbury">
-            <circle cx="67.66" cy="122.1" r="1"/>
-            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hampshire">
-          <g id="Southampton">
-            <circle cx="71.5" cy="125" r="1"/>
-            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Portsmouth">
-            <circle cx="73.5" cy="125.5" r="1"/>
-            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Winchester">
-            <circle cx="72.3" cy="122.1" r="1"/>
-            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Sussex">
-          <g id="Chichester">
-            <circle cx="75.58" cy="124.93" r="1"/>
-            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Sussex">
-          <g id="Brighton and Hove">
-            <circle cx="80.67" cy="124.93" r="1"/>
-            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Kent">
-          <g id="Canterbury">
-            <circle cx="89.94" cy="119.84" r="1"/>
-            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater London">
-          <g id="City of Westminster">
-            <circle cx="79.54" cy="117.01" r="1"/>
-            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Oxfordshire">
-          <g id="Oxford">
-            <circle cx="71.62" cy="113.62" r="1"/>
-            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hertfordshire">
-          <g id="St Albans">
-            <circle cx="78.97" cy="113.62" r="1"/>
-            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Essex">
-          <g id="Chelmsford">
-            <circle cx="85.19" cy="113.62" r="1"/>
-            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Colchester">
-            <circle cx="88.03" cy="112.06" r="1"/>
-            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Southend-on-Sea">
-            <circle cx="86.81" cy="116.72" r="1"/>
-            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gloucestershire">
-          <g id="Gloucester">
-            <circle cx="64.26" cy="113.05" r="1"/>
-            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Dyfed">
-          <g id="St Davids">
-            <circle cx="43.67" cy="112.49" r="1"/>
-            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Herefordshire">
-          <g id="Hereford">
-            <circle cx="61.1" cy="110.79" r="1"/>
-            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Worcestershire">
-          <g id="Worcester">
-            <circle cx="64.83" cy="109.09" r="1"/>
-            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cambridgeshire">
-          <g id="Cambridge">
-            <circle cx="81.23" cy="108.53" r="1"/>
-            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ely">
-            <circle cx="81.57" cy="106.27" r="1"/>
-            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Peterborough">
-            <circle cx="78.97" cy="104" r="1"/>
-            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Midlands (county)">
-          <g id="Coventry">
-            <circle cx="69.35" cy="106.27" r="1"/>
-            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Birmingham">
-            <circle cx="67.09" cy="105.14" r="1"/>
-            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wolverhampton">
-            <circle cx="65.39" cy="104" r="1"/>
-            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g if="Norfolk">
-          <g id="Norwich">
-            <circle cx="89.72" cy="103.44" r="1"/>
-            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Leicestershire">
-          <g id="Leicester">
-            <circle cx="72.52" cy="103.44" r="1"/>
-            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Staffordshire">
-          <g id="Lichfield">
-            <circle cx="67.88" cy="103.44" r="1"/>
-            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Stoke-on-Trent">
-            <circle cx="65.39" cy="98.91" r="1"/>
-            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Nottinghamshire">
-          <g id="Nottingham">
-            <circle cx="72.52" cy="100.04" r="1"/>
-            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Derbyshire">
-          <g id="Derby">
-            <circle cx="69.92" cy="99.48" r="1"/>
-            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lincolnshire">
-          <g id="Lincoln">
-            <circle cx="77.27" cy="97.78" r="1"/>
-            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Yorkshire">
-          <g id="Doncaster">
-            <circle cx="72.613" cy="92.65" r="1"/>
-            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Sheffield">
-            <circle cx="69.35" cy="94.39" r="1"/>
-            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater Manchester">
-          <g id="Manchester">
-            <circle cx="64.83" cy="93.26" r="1"/>
-            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Salford">
-            <circle cx="63.92" cy="93.48" r="1"/>
-            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Merseyside">
-          <g id="Liverpool">
-            <circle cx="59.17" cy="94.39" r="1"/>
-            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cheshire">
-          <g id="Chester">
-            <circle cx="60.3" cy="96.65" r="1"/>
-            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Clwyd">
-          <g id="St Asaph">
-            <circle cx="56.91" cy="96.65" r="1"/>
-            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wrexham">
-            <circle cx="59.30" cy="97.79" r="1"/>
-            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwynedd">
-          <g id="Bangor">
-            <circle cx="50.69" cy="96.65" r="1"/>
-            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Riding of Yorkshire">
-          <g id="Kingston upon Hull">
-            <circle cx="78.4" cy="89.3" r="1"/>
-            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Yorkshire">
-          <g id="Wakefield">
-            <circle cx="70.49" cy="90.99" r="1"/>
-            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Leeds">
-            <circle cx="69.35" cy="89.3" r="1"/>
-            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Bradford">
-            <circle cx="67.09" cy="89.3" r="1"/>
-            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lancashire">
-          <g id="Preston">
-            <circle cx="61.43" cy="89.3" r="1"/>
-            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lancaster">
-            <circle cx="61.43" cy="86.47" r="1"/>
-            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="North Yorkshire">
-          <g id="York">
-            <circle cx="72.75" cy="87.6" r="1"/>
-            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ripon">
-            <circle cx="69.92" cy="85.34" r="1"/>
-            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Durham">
-          <g id="Durham">
-            <circle cx="69.35" cy="78.55" r="1"/>
-            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Tyne and Wear">
-          <g id="Sunderland">
-            <circle cx="69.92" cy="76.29" r="1"/>
-            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newcastle upon Tyne">
-            <circle cx="68.79" cy="75.15" r="1"/>
-            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cumbria">
-          <g id="Carlisle">
-            <circle cx="60.3" cy="75.72" r="1"/>
-            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Buckinghamshire">
-          <g id="Milton Keynes">
-            <circle cx="75.50" cy="110.91" r="1"/>
-            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwent (county)">
-          <g id="Newport">
-            <circle cx="58.04" cy="115.88" r="1"/>
-            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Glamorgan">
-          <g id="Cardiff">
-            <circle cx="56.91" cy="117.01" r="1"/>
-            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Glamorgan">
-          <g id="Swansea">
-            <circle cx="52.95" cy="114.75" r="1"/>
-            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Stirling (council area)">
-          <g id="Stirling">
-            <circle cx="51.35" cy="61.00" r="1"/>
-            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Perth and Kinross">
-          <g id="Perth">
-            <circle cx="54.72" cy="58.42" r="1"/>
-            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Highland (council area)">
-          <g id="Inverness">
-            <circle cx="49.39" cy="44.2" r="1"/>
-            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Fife">
-          <g id="Dunfermline">
-            <circle cx="55.61" cy="61.85" r="1"/>
-            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Down">
-          <g id="Bangor">
-            <circle cx="39.00" cy="79.86" r="1"/>
-            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Londonderry">
-          <g id="Derry">
-            <circle cx="27.11" cy="75.92" r="1"/>
-            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh / County Down">
-          <g id="Newry">
-            <circle cx="33.87" cy="86.58" r="1"/>
-            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bangor, Gwynedd">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh">
-          <g id="Armagh">
-            <circle cx="31.45" cy="84.59" r="1"/>
-            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Antrim / County Down">
-          <g id="Belfast">
-            <circle cx="36.41" cy="80.88" r="1"/>
-            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lisburn">
-            <circle cx="34.64" cy="81.71" r="1"/>
-            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bangor, County Down">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -720,385 +620,285 @@
       </g>
     </g>
     <g id="Cities">
-      <g id="Somerset">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Bath">
+        <circle cx="63.13" cy="119.28" r="1"/>
+        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cornwall">
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Truro">
+        <circle cx="42.77" cy="132.85" r="1"/>
+        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Decon">
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Plymouth">
+        <circle cx="50.12" cy="130.59" r="1"/>
+        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Wiltshire">
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Exeter">
+        <circle cx="54.08" cy="127.2" r="1"/>
+        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Hampshire">
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wells">
+        <circle cx="60.87" cy="120.41" r="1"/>
+        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Sussex">
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Salisbury">
+        <circle cx="67.66" cy="122.1" r="1"/>
+        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="East Sussex">
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Southampton">
+        <circle cx="71.5" cy="125" r="1"/>
+        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Kent">
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Portsmouth">
+        <circle cx="73.5" cy="125.5" r="1"/>
+        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Greater London">
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chichester">
+        <circle cx="75.58" cy="124.93" r="1"/>
+        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Oxfordshire">
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Winchester">
+        <circle cx="72.3" cy="122.1" r="1"/>
+        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Hertfordshire">
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Brighton and Hove">
+        <circle cx="80.67" cy="124.93" r="1"/>
+        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Essex">
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Colchester">
-          <circle cx="88.03" cy="112.06" r="1"/>
-          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Southend-on-Sea">
-          <circle cx="86.81" cy="116.72" r="1"/>
-          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Canterbury">
+        <circle cx="89.94" cy="119.84" r="1"/>
+        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gloucestershire">
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="City of Westminster">
+        <circle cx="79.54" cy="117.01" r="1"/>
+        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Dyfed">
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Southend-on-Sea">
+        <circle cx="86.81" cy="116.72" r="1"/>
+        <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Herefordshire">
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Oxford">
+        <circle cx="71.62" cy="113.62" r="1"/>
+        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Worcestershire">
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Albans">
+        <circle cx="78.97" cy="113.62" r="1"/>
+        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cambridgeshire">
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chelmsford">
+        <circle cx="85.19" cy="113.62" r="1"/>
+        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Midlands (county)">
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Newport">
+        <circle cx="58.04" cy="115.88" r="1"/>
+        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g if="Norfolk">
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Cardiff">
+        <circle cx="56.91" cy="117.01" r="1"/>
+        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Leicestershire">
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Swansea">
+        <circle cx="52.95" cy="114.75" r="1"/>
+        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Staffordshire">
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Gloucester">
+        <circle cx="64.26" cy="113.05" r="1"/>
+        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Nottinghamshire">
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Colchester">
+        <circle cx="88.03" cy="112.06" r="1"/>
+        <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Derbyshire">
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Davids">
+        <circle cx="43.67" cy="112.49" r="1"/>
+        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Lincolnshire">
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Milton Keynes">
+        <circle cx="75.50" cy="110.91" r="1"/>
+        <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="South Yorkshire">
-        <g id="Doncaster">
-          <circle cx="72.613" cy="92.65" r="1"/>
-          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Hereford">
+        <circle cx="61.1" cy="110.79" r="1"/>
+        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Greater Manchester">
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Worcester">
+        <circle cx="64.83" cy="109.09" r="1"/>
+        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Merseyside">
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Cambridge">
+        <circle cx="81.23" cy="108.53" r="1"/>
+        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cheshire">
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Ely">
+        <circle cx="81.57" cy="106.27" r="1"/>
+        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Clwyd">
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wrexham">
-          <circle cx="59.30" cy="97.79" r="1"/>
-          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Coventry">
+        <circle cx="69.35" cy="106.27" r="1"/>
+        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gwynedd">
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Birmingham">
+        <circle cx="67.09" cy="105.14" r="1"/>
+        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="East Riding of Yorkshire">
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wolverhampton">
+        <circle cx="65.39" cy="104" r="1"/>
+        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Yorkshire">
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Norwich">
+        <circle cx="89.72" cy="103.44" r="1"/>
+        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Lancashire">
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Peterborough">
+        <circle cx="78.97" cy="104" r="1"/>
+        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="North Yorkshire">
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Leicester">
+        <circle cx="72.52" cy="103.44" r="1"/>
+        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Durham">
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Lichfield">
+        <circle cx="67.88" cy="103.44" r="1"/>
+        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Tyne and Wear">
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Nottingham">
+        <circle cx="72.52" cy="100.04" r="1"/>
+        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cumbria">
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Derby">
+        <circle cx="69.92" cy="99.48" r="1"/>
+        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Buckinghamshire">
-        <g id="Milton Keynes">
-          <circle cx="75.50" cy="110.91" r="1"/>
-          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Stoke-on-Trent">
+        <circle cx="65.39" cy="98.91" r="1"/>
+        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gwent (county)">
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Lincoln">
+        <circle cx="77.27" cy="97.78" r="1"/>
+        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="South Glamorgan">
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Sheffield">
+        <circle cx="69.35" cy="94.39" r="1"/>
+        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Glamorgan">
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Doncaster">
+        <circle cx="72.613" cy="92.65" r="1"/>
+        <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Stirling (council area)">
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Manchester">
+        <circle cx="64.83" cy="93.26" r="1"/>
+        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Perth and Kinross">
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Salford">
+        <circle cx="63.92" cy="93.48" r="1"/>
+        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Highland (council area)">
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Liverpool">
+        <circle cx="59.17" cy="94.39" r="1"/>
+        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Fife">
-        <g id="Dunfermline">
-          <circle cx="55.61" cy="61.85" r="1"/>
-          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chester">
+        <circle cx="60.3" cy="96.65" r="1"/>
+        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Down">
-        <g id="Bangor">
-          <circle cx="39.00" cy="79.86" r="1"/>
-          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Asaph">
+        <circle cx="56.91" cy="96.65" r="1"/>
+        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Londonderry">
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wrexham">
+        <circle cx="59.30" cy="97.79" r="1"/>
+        <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Armagh / County Down">
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Bangor, Gwynedd">
+        <circle cx="50.69" cy="96.65" r="1"/>
+        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Armagh">
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Kingston upon Hull">
+        <circle cx="78.4" cy="89.3" r="1"/>
+        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Antrim / County Down">
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wakefield">
+        <circle cx="70.49" cy="90.99" r="1"/>
+        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Leeds">
+        <circle cx="69.35" cy="89.3" r="1"/>
+        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bradford">
+        <circle cx="67.09" cy="89.3" r="1"/>
+        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Preston">
+        <circle cx="61.43" cy="89.3" r="1"/>
+        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lancaster">
+        <circle cx="61.43" cy="86.47" r="1"/>
+        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="York">
+        <circle cx="72.75" cy="87.6" r="1"/>
+        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Ripon">
+        <circle cx="69.92" cy="85.34" r="1"/>
+        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Durham">
+        <circle cx="69.35" cy="78.55" r="1"/>
+        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Sunderland">
+        <circle cx="69.92" cy="76.29" r="1"/>
+        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newcastle upon Tyne">
+        <circle cx="68.79" cy="75.15" r="1"/>
+        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Carlisle">
+        <circle cx="60.3" cy="75.72" r="1"/>
+        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Dunfermline">
+        <circle cx="55.61" cy="61.85" r="1"/>
+        <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Stirling">
+        <circle cx="51.35" cy="61.00" r="1"/>
+        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Perth">
+        <circle cx="54.72" cy="58.42" r="1"/>
+        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Inverness">
+        <circle cx="49.39" cy="44.2" r="1"/>
+        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Derry">
+        <circle cx="27.11" cy="75.92" r="1"/>
+        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newry">
+        <circle cx="33.87" cy="86.58" r="1"/>
+        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bangor, County Down">
+        <circle cx="39.00" cy="79.86" r="1"/>
+        <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Armagh">
+        <circle cx="31.45" cy="84.59" r="1"/>
+        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Belfast">
+        <circle cx="36.41" cy="80.88" r="1"/>
+        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lisburn">
+        <circle cx="34.64" cy="81.71" r="1"/>
+        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
     </g>
     <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/Map - City.html
+++ b/src/note_models/UK_Geog/templates/Map - City.html
@@ -261,6 +261,14 @@
             <circle cx="85.19" cy="113.62" r="1"/>
             <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
+          <g id="Colchester">
+            <circle cx="88.03" cy="112.06" r="1"/>
+            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Southend-on-Sea">
+            <circle cx="86.81" cy="116.72" r="1"/>
+            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
         <g id="Gloucestershire">
           <g id="Gloucester">
@@ -355,6 +363,10 @@
           </g>
         </g>
         <g id="South Yorkshire">
+          <g id="Doncaster">
+            <circle cx="72.613" cy="92.65" r="1"/>
+            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
           <g id="Sheffield">
             <circle cx="69.35" cy="94.39" r="1"/>
             <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -386,6 +398,10 @@
           <g id="St Asaph">
             <circle cx="56.91" cy="96.65" r="1"/>
             <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wrexham">
+            <circle cx="59.30" cy="97.79" r="1"/>
+            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="Gwynedd">
@@ -456,6 +472,12 @@
             <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
+        <g id="Buckinghamshire">
+          <g id="Milton Keynes">
+            <circle cx="75.50" cy="110.91" r="1"/>
+            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
         <g id="Gwent (county)">
           <g id="Newport">
             <circle cx="58.04" cy="115.88" r="1"/>
@@ -490,6 +512,18 @@
           <g id="Inverness">
             <circle cx="49.39" cy="44.2" r="1"/>
             <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="Fife">
+          <g id="Dunfermline">
+            <circle cx="55.61" cy="61.85" r="1"/>
+            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="County Down">
+          <g id="Bangor">
+            <circle cx="39.00" cy="79.86" r="1"/>
+            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="County Londonderry">
@@ -801,6 +835,14 @@
           <circle cx="85.19" cy="113.62" r="1"/>
           <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
       <g id="Gloucestershire">
         <g id="Gloucester">
@@ -895,6 +937,10 @@
         </g>
       </g>
       <g id="South Yorkshire">
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
         <g id="Sheffield">
           <circle cx="69.35" cy="94.39" r="1"/>
           <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -926,6 +972,10 @@
         <g id="St Asaph">
           <circle cx="56.91" cy="96.65" r="1"/>
           <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <g id="Gwynedd">
@@ -996,6 +1046,12 @@
           <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
+      <g id="Buckinghamshire">
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
       <g id="Gwent (county)">
         <g id="Newport">
           <circle cx="58.04" cy="115.88" r="1"/>
@@ -1030,6 +1086,18 @@
         <g id="Inverness">
           <circle cx="49.39" cy="44.2" r="1"/>
           <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
+      <g id="Fife">
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+      </g>
+      <g id="County Down">
+        <g id="Bangor">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <g id="County Londonderry">

--- a/src/note_models/UK_Geog/templates/Map - City.html
+++ b/src/note_models/UK_Geog/templates/Map - City.html
@@ -1,6 +1,8 @@
 {{#City}}
   <style>
-    [id="Bodies of Water"], [id='Cities'] > :not([id="{{City}}"]){
+    [id='Cities'] > :not([id='{{MacroLocation}}']),
+    [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
+    [id='Bodies of Water'] {
       visibility: hidden;
     }
     [id='{{City}}'].cityCounty {
@@ -172,261 +174,356 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Somerset">
+          <g id="Bath">
+            <circle cx="63.13" cy="119.28" r="1"/>
+            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wells">
+            <circle cx="60.87" cy="120.41" r="1"/>
+            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cornwall">
+          <g id="Truro">
+            <circle cx="42.77" cy="132.85" r="1"/>
+            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Decon">
+          <g id="Plymouth">
+            <circle cx="50.12" cy="130.59" r="1"/>
+            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Exeter">
+            <circle cx="54.08" cy="127.2" r="1"/>
+            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Wiltshire">
+          <g id="Salisbury">
+            <circle cx="67.66" cy="122.1" r="1"/>
+            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hampshire">
+          <g id="Southampton">
+            <circle cx="71.5" cy="125" r="1"/>
+            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Portsmouth">
+            <circle cx="73.5" cy="125.5" r="1"/>
+            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Winchester">
+            <circle cx="72.3" cy="122.1" r="1"/>
+            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Sussex">
+          <g id="Chichester">
+            <circle cx="75.58" cy="124.93" r="1"/>
+            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Sussex">
+          <g id="Brighton and Hove">
+            <circle cx="80.67" cy="124.93" r="1"/>
+            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Kent">
+          <g id="Canterbury">
+            <circle cx="89.94" cy="119.84" r="1"/>
+            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater London">
+          <g id="City of Westminster">
+            <circle cx="79.54" cy="117.01" r="1"/>
+            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Oxfordshire">
+          <g id="Oxford">
+            <circle cx="71.62" cy="113.62" r="1"/>
+            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hertfordshire">
+          <g id="St Albans">
+            <circle cx="78.97" cy="113.62" r="1"/>
+            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Essex">
+          <g id="Chelmsford">
+            <circle cx="85.19" cy="113.62" r="1"/>
+            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gloucestershire">
+          <g id="Gloucester">
+            <circle cx="64.26" cy="113.05" r="1"/>
+            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Dyfed">
+          <g id="St Davids">
+            <circle cx="43.67" cy="112.49" r="1"/>
+            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Herefordshire">
+          <g id="Hereford">
+            <circle cx="61.1" cy="110.79" r="1"/>
+            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Worcestershire">
+          <g id="Worcester">
+            <circle cx="64.83" cy="109.09" r="1"/>
+            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cambridgeshire">
+          <g id="Cambridge">
+            <circle cx="81.23" cy="108.53" r="1"/>
+            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ely">
+            <circle cx="81.57" cy="106.27" r="1"/>
+            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Peterborough">
+            <circle cx="78.97" cy="104" r="1"/>
+            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Midlands (county)">
+          <g id="Coventry">
+            <circle cx="69.35" cy="106.27" r="1"/>
+            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Birmingham">
+            <circle cx="67.09" cy="105.14" r="1"/>
+            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wolverhampton">
+            <circle cx="65.39" cy="104" r="1"/>
+            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g if="Norfolk">
+          <g id="Norwich">
+            <circle cx="89.72" cy="103.44" r="1"/>
+            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Leicestershire">
+          <g id="Leicester">
+            <circle cx="72.52" cy="103.44" r="1"/>
+            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Staffordshire">
+          <g id="Lichfield">
+            <circle cx="67.88" cy="103.44" r="1"/>
+            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Stoke-on-Trent">
+            <circle cx="65.39" cy="98.91" r="1"/>
+            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Nottinghamshire">
+          <g id="Nottingham">
+            <circle cx="72.52" cy="100.04" r="1"/>
+            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Derbyshire">
+          <g id="Derby">
+            <circle cx="69.92" cy="99.48" r="1"/>
+            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lincolnshire">
+          <g id="Lincoln">
+            <circle cx="77.27" cy="97.78" r="1"/>
+            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Yorkshire">
+          <g id="Sheffield">
+            <circle cx="69.35" cy="94.39" r="1"/>
+            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater Manchester">
+          <g id="Manchester">
+            <circle cx="64.83" cy="93.26" r="1"/>
+            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Salford">
+            <circle cx="63.92" cy="93.48" r="1"/>
+            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Merseyside">
+          <g id="Liverpool">
+            <circle cx="59.17" cy="94.39" r="1"/>
+            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cheshire">
+          <g id="Chester">
+            <circle cx="60.3" cy="96.65" r="1"/>
+            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Clwyd">
+          <g id="St Asaph">
+            <circle cx="56.91" cy="96.65" r="1"/>
+            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwynedd">
+          <g id="Bangor">
+            <circle cx="50.69" cy="96.65" r="1"/>
+            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Riding of Yorkshire">
+          <g id="Kingston upon Hull">
+            <circle cx="78.4" cy="89.3" r="1"/>
+            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Yorkshire">
+          <g id="Wakefield">
+            <circle cx="70.49" cy="90.99" r="1"/>
+            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Leeds">
+            <circle cx="69.35" cy="89.3" r="1"/>
+            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bradford">
+            <circle cx="67.09" cy="89.3" r="1"/>
+            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lancashire">
+          <g id="Preston">
+            <circle cx="61.43" cy="89.3" r="1"/>
+            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lancaster">
+            <circle cx="61.43" cy="86.47" r="1"/>
+            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="North Yorkshire">
+          <g id="York">
+            <circle cx="72.75" cy="87.6" r="1"/>
+            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ripon">
+            <circle cx="69.92" cy="85.34" r="1"/>
+            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Durham">
+          <g id="Durham">
+            <circle cx="69.35" cy="78.55" r="1"/>
+            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Tyne and Wear">
+          <g id="Sunderland">
+            <circle cx="69.92" cy="76.29" r="1"/>
+            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newcastle upon Tyne">
+            <circle cx="68.79" cy="75.15" r="1"/>
+            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cumbria">
+          <g id="Carlisle">
+            <circle cx="60.3" cy="75.72" r="1"/>
+            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwent (county)">
+          <g id="Newport">
+            <circle cx="58.04" cy="115.88" r="1"/>
+            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Glamorgan">
+          <g id="Cardiff">
+            <circle cx="56.91" cy="117.01" r="1"/>
+            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Glamorgan">
+          <g id="Swansea">
+            <circle cx="52.95" cy="114.75" r="1"/>
+            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Stirling (council area)">
+          <g id="Stirling">
+            <circle cx="51.35" cy="61.00" r="1"/>
+            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Perth and Kinross">
+          <g id="Perth">
+            <circle cx="54.72" cy="58.42" r="1"/>
+            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Highland (council area)">
+          <g id="Inverness">
+            <circle cx="49.39" cy="44.2" r="1"/>
+            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Londonderry">
+          <g id="Derry">
+            <circle cx="27.11" cy="75.92" r="1"/>
+            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh / County Down">
+          <g id="Newry">
+            <circle cx="33.87" cy="86.58" r="1"/>
+            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh">
+          <g id="Armagh">
+            <circle cx="31.45" cy="84.59" r="1"/>
+            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Antrim / County Down">
+          <g id="Belfast">
+            <circle cx="36.41" cy="80.88" r="1"/>
+            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lisburn">
+            <circle cx="34.64" cy="81.71" r="1"/>
+            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
     </svg>
+
      
   </div>
   <script>
@@ -442,7 +539,9 @@
 --
 
 <style>
-  [id="Bodies of Water"], [id='Cities'] > :not([id="{{City}}"]){
+  [id='Cities'] > :not([id='{{MacroLocation}}']),
+  [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
+  [id='Bodies of Water'] {
     visibility: hidden;
   }
   [id='{{City}}'].cityCounty {
@@ -615,261 +714,356 @@
       </g>
     </g>
     <g id="Cities">
-      <g id="Bath">
-        <circle cx="63.13" cy="119.28" r="1"/>
-        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Somerset">
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Truro">
-        <circle cx="42.77" cy="132.85" r="1"/>
-        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cornwall">
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Plymouth">
-        <circle cx="50.12" cy="130.59" r="1"/>
-        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Decon">
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Exeter">
-        <circle cx="54.08" cy="127.2" r="1"/>
-        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Wiltshire">
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wells">
-        <circle cx="60.87" cy="120.41" r="1"/>
-        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Hampshire">
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Salisbury">
-        <circle cx="67.66" cy="122.1" r="1"/>
-        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Sussex">
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Southampton">
-        <circle cx="71.5" cy="125" r="1"/>
-        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="East Sussex">
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Portsmouth">
-        <circle cx="73.5" cy="125.5" r="1"/>
-        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Kent">
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chichester">
-        <circle cx="75.58" cy="124.93" r="1"/>
-        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Greater London">
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Winchester">
-        <circle cx="72.3" cy="122.1" r="1"/>
-        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Oxfordshire">
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Brighton and Hove">
-        <circle cx="80.67" cy="124.93" r="1"/>
-        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Hertfordshire">
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Canterbury">
-        <circle cx="89.94" cy="119.84" r="1"/>
-        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Essex">
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="City of Westminster">
-        <circle cx="79.54" cy="117.01" r="1"/>
-        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gloucestershire">
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Oxford">
-        <circle cx="71.62" cy="113.62" r="1"/>
-        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Dyfed">
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Albans">
-        <circle cx="78.97" cy="113.62" r="1"/>
-        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Herefordshire">
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chelmsford">
-        <circle cx="85.19" cy="113.62" r="1"/>
-        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Worcestershire">
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Newport">
-        <circle cx="58.04" cy="115.88" r="1"/>
-        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cambridgeshire">
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Cardiff">
-        <circle cx="56.91" cy="117.01" r="1"/>
-        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Midlands (county)">
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Swansea">
-        <circle cx="52.95" cy="114.75" r="1"/>
-        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g if="Norfolk">
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Gloucester">
-        <circle cx="64.26" cy="113.05" r="1"/>
-        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Leicestershire">
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Davids">
-        <circle cx="43.67" cy="112.49" r="1"/>
-        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Staffordshire">
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Hereford">
-        <circle cx="61.1" cy="110.79" r="1"/>
-        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Nottinghamshire">
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Worcester">
-        <circle cx="64.83" cy="109.09" r="1"/>
-        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Derbyshire">
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Cambridge">
-        <circle cx="81.23" cy="108.53" r="1"/>
-        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Lincolnshire">
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Ely">
-        <circle cx="81.57" cy="106.27" r="1"/>
-        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="South Yorkshire">
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Coventry">
-        <circle cx="69.35" cy="106.27" r="1"/>
-        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Greater Manchester">
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Birmingham">
-        <circle cx="67.09" cy="105.14" r="1"/>
-        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Merseyside">
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wolverhampton">
-        <circle cx="65.39" cy="104" r="1"/>
-        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cheshire">
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Norwich">
-        <circle cx="89.72" cy="103.44" r="1"/>
-        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Clwyd">
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Peterborough">
-        <circle cx="78.97" cy="104" r="1"/>
-        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gwynedd">
+        <g id="Bangor">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Leicester">
-        <circle cx="72.52" cy="103.44" r="1"/>
-        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="East Riding of Yorkshire">
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Lichfield">
-        <circle cx="67.88" cy="103.44" r="1"/>
-        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Yorkshire">
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Nottingham">
-        <circle cx="72.52" cy="100.04" r="1"/>
-        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Lancashire">
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Derby">
-        <circle cx="69.92" cy="99.48" r="1"/>
-        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="North Yorkshire">
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Stoke-on-Trent">
-        <circle cx="65.39" cy="98.91" r="1"/>
-        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Durham">
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Lincoln">
-        <circle cx="77.27" cy="97.78" r="1"/>
-        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Tyne and Wear">
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Sheffield">
-        <circle cx="69.35" cy="94.39" r="1"/>
-        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Cumbria">
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Manchester">
-        <circle cx="64.83" cy="93.26" r="1"/>
-        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Gwent (county)">
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Salford">
-        <circle cx="63.92" cy="93.48" r="1"/>
-        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="South Glamorgan">
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Liverpool">
-        <circle cx="59.17" cy="94.39" r="1"/>
-        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="West Glamorgan">
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Chester">
-        <circle cx="60.3" cy="96.65" r="1"/>
-        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Stirling (council area)">
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="St Asaph">
-        <circle cx="56.91" cy="96.65" r="1"/>
-        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Perth and Kinross">
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Bangor">
-        <circle cx="50.69" cy="96.65" r="1"/>
-        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="Highland (council area)">
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Kingston upon Hull">
-        <circle cx="78.4" cy="89.3" r="1"/>
-        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Londonderry">
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Wakefield">
-        <circle cx="70.49" cy="90.99" r="1"/>
-        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Armagh / County Down">
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Leeds">
-        <circle cx="69.35" cy="89.3" r="1"/>
-        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Armagh">
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
-      <g id="Bradford">
-        <circle cx="67.09" cy="89.3" r="1"/>
-        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Preston">
-        <circle cx="61.43" cy="89.3" r="1"/>
-        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lancaster">
-        <circle cx="61.43" cy="86.47" r="1"/>
-        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="York">
-        <circle cx="72.75" cy="87.6" r="1"/>
-        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Ripon">
-        <circle cx="69.92" cy="85.34" r="1"/>
-        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Durham">
-        <circle cx="69.35" cy="78.55" r="1"/>
-        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Sunderland">
-        <circle cx="69.92" cy="76.29" r="1"/>
-        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newcastle upon Tyne">
-        <circle cx="68.79" cy="75.15" r="1"/>
-        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Carlisle">
-        <circle cx="60.3" cy="75.72" r="1"/>
-        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Stirling">
-        <circle cx="51.35" cy="61.00" r="1"/>
-        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Perth">
-        <circle cx="54.72" cy="58.42" r="1"/>
-        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Inverness">
-        <circle cx="49.39" cy="44.2" r="1"/>
-        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Derry">
-        <circle cx="27.11" cy="75.92" r="1"/>
-        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Newry">
-        <circle cx="33.87" cy="86.58" r="1"/>
-        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Armagh">
-        <circle cx="31.45" cy="84.59" r="1"/>
-        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Belfast">
-        <circle cx="36.41" cy="80.88" r="1"/>
-        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-      </g>
-      <g id="Lisburn">
-        <circle cx="34.64" cy="81.71" r="1"/>
-        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      <g id="County Antrim / County Down">
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
       </g>
     </g>
     <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
   </svg>
+
     
 </div>
 <script>

--- a/src/note_models/UK_Geog/templates/Map - City.html
+++ b/src/note_models/UK_Geog/templates/Map - City.html
@@ -1,8 +1,6 @@
 {{#City}}
   <style>
-    [id='Cities'] > :not([id='{{MacroLocation}}']),
-    [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
-    [id='Bodies of Water'] {
+    [id='Cities'] > :not([id='{{Location}}']), [id='Bodies of Water'] {
       visibility: hidden;
     }
     [id='{{City}}'].cityCounty {
@@ -174,385 +172,285 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Somerset">
-          <g id="Bath">
-            <circle cx="63.13" cy="119.28" r="1"/>
-            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wells">
-            <circle cx="60.87" cy="120.41" r="1"/>
-            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cornwall">
-          <g id="Truro">
-            <circle cx="42.77" cy="132.85" r="1"/>
-            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Decon">
-          <g id="Plymouth">
-            <circle cx="50.12" cy="130.59" r="1"/>
-            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Exeter">
-            <circle cx="54.08" cy="127.2" r="1"/>
-            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Wiltshire">
-          <g id="Salisbury">
-            <circle cx="67.66" cy="122.1" r="1"/>
-            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hampshire">
-          <g id="Southampton">
-            <circle cx="71.5" cy="125" r="1"/>
-            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Portsmouth">
-            <circle cx="73.5" cy="125.5" r="1"/>
-            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Winchester">
-            <circle cx="72.3" cy="122.1" r="1"/>
-            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Sussex">
-          <g id="Chichester">
-            <circle cx="75.58" cy="124.93" r="1"/>
-            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Sussex">
-          <g id="Brighton and Hove">
-            <circle cx="80.67" cy="124.93" r="1"/>
-            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Kent">
-          <g id="Canterbury">
-            <circle cx="89.94" cy="119.84" r="1"/>
-            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater London">
-          <g id="City of Westminster">
-            <circle cx="79.54" cy="117.01" r="1"/>
-            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Oxfordshire">
-          <g id="Oxford">
-            <circle cx="71.62" cy="113.62" r="1"/>
-            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hertfordshire">
-          <g id="St Albans">
-            <circle cx="78.97" cy="113.62" r="1"/>
-            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Essex">
-          <g id="Chelmsford">
-            <circle cx="85.19" cy="113.62" r="1"/>
-            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Colchester">
-            <circle cx="88.03" cy="112.06" r="1"/>
-            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Southend-on-Sea">
-            <circle cx="86.81" cy="116.72" r="1"/>
-            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gloucestershire">
-          <g id="Gloucester">
-            <circle cx="64.26" cy="113.05" r="1"/>
-            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Dyfed">
-          <g id="St Davids">
-            <circle cx="43.67" cy="112.49" r="1"/>
-            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Herefordshire">
-          <g id="Hereford">
-            <circle cx="61.1" cy="110.79" r="1"/>
-            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Worcestershire">
-          <g id="Worcester">
-            <circle cx="64.83" cy="109.09" r="1"/>
-            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cambridgeshire">
-          <g id="Cambridge">
-            <circle cx="81.23" cy="108.53" r="1"/>
-            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ely">
-            <circle cx="81.57" cy="106.27" r="1"/>
-            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Peterborough">
-            <circle cx="78.97" cy="104" r="1"/>
-            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Midlands (county)">
-          <g id="Coventry">
-            <circle cx="69.35" cy="106.27" r="1"/>
-            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Birmingham">
-            <circle cx="67.09" cy="105.14" r="1"/>
-            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wolverhampton">
-            <circle cx="65.39" cy="104" r="1"/>
-            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g if="Norfolk">
-          <g id="Norwich">
-            <circle cx="89.72" cy="103.44" r="1"/>
-            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Leicestershire">
-          <g id="Leicester">
-            <circle cx="72.52" cy="103.44" r="1"/>
-            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Staffordshire">
-          <g id="Lichfield">
-            <circle cx="67.88" cy="103.44" r="1"/>
-            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Stoke-on-Trent">
-            <circle cx="65.39" cy="98.91" r="1"/>
-            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Nottinghamshire">
-          <g id="Nottingham">
-            <circle cx="72.52" cy="100.04" r="1"/>
-            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Derbyshire">
-          <g id="Derby">
-            <circle cx="69.92" cy="99.48" r="1"/>
-            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lincolnshire">
-          <g id="Lincoln">
-            <circle cx="77.27" cy="97.78" r="1"/>
-            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Yorkshire">
-          <g id="Doncaster">
-            <circle cx="72.613" cy="92.65" r="1"/>
-            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Sheffield">
-            <circle cx="69.35" cy="94.39" r="1"/>
-            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater Manchester">
-          <g id="Manchester">
-            <circle cx="64.83" cy="93.26" r="1"/>
-            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Salford">
-            <circle cx="63.92" cy="93.48" r="1"/>
-            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Merseyside">
-          <g id="Liverpool">
-            <circle cx="59.17" cy="94.39" r="1"/>
-            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cheshire">
-          <g id="Chester">
-            <circle cx="60.3" cy="96.65" r="1"/>
-            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Clwyd">
-          <g id="St Asaph">
-            <circle cx="56.91" cy="96.65" r="1"/>
-            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wrexham">
-            <circle cx="59.30" cy="97.79" r="1"/>
-            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwynedd">
-          <g id="Bangor">
-            <circle cx="50.69" cy="96.65" r="1"/>
-            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Riding of Yorkshire">
-          <g id="Kingston upon Hull">
-            <circle cx="78.4" cy="89.3" r="1"/>
-            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Yorkshire">
-          <g id="Wakefield">
-            <circle cx="70.49" cy="90.99" r="1"/>
-            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Leeds">
-            <circle cx="69.35" cy="89.3" r="1"/>
-            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Bradford">
-            <circle cx="67.09" cy="89.3" r="1"/>
-            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lancashire">
-          <g id="Preston">
-            <circle cx="61.43" cy="89.3" r="1"/>
-            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lancaster">
-            <circle cx="61.43" cy="86.47" r="1"/>
-            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="North Yorkshire">
-          <g id="York">
-            <circle cx="72.75" cy="87.6" r="1"/>
-            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ripon">
-            <circle cx="69.92" cy="85.34" r="1"/>
-            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Durham">
-          <g id="Durham">
-            <circle cx="69.35" cy="78.55" r="1"/>
-            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Tyne and Wear">
-          <g id="Sunderland">
-            <circle cx="69.92" cy="76.29" r="1"/>
-            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newcastle upon Tyne">
-            <circle cx="68.79" cy="75.15" r="1"/>
-            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cumbria">
-          <g id="Carlisle">
-            <circle cx="60.3" cy="75.72" r="1"/>
-            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Buckinghamshire">
-          <g id="Milton Keynes">
-            <circle cx="75.50" cy="110.91" r="1"/>
-            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwent (county)">
-          <g id="Newport">
-            <circle cx="58.04" cy="115.88" r="1"/>
-            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Glamorgan">
-          <g id="Cardiff">
-            <circle cx="56.91" cy="117.01" r="1"/>
-            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Glamorgan">
-          <g id="Swansea">
-            <circle cx="52.95" cy="114.75" r="1"/>
-            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Stirling (council area)">
-          <g id="Stirling">
-            <circle cx="51.35" cy="61.00" r="1"/>
-            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Perth and Kinross">
-          <g id="Perth">
-            <circle cx="54.72" cy="58.42" r="1"/>
-            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Highland (council area)">
-          <g id="Inverness">
-            <circle cx="49.39" cy="44.2" r="1"/>
-            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Fife">
-          <g id="Dunfermline">
-            <circle cx="55.61" cy="61.85" r="1"/>
-            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Down">
-          <g id="Bangor">
-            <circle cx="39.00" cy="79.86" r="1"/>
-            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Londonderry">
-          <g id="Derry">
-            <circle cx="27.11" cy="75.92" r="1"/>
-            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh / County Down">
-          <g id="Newry">
-            <circle cx="33.87" cy="86.58" r="1"/>
-            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bangor, Gwynedd">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh">
-          <g id="Armagh">
-            <circle cx="31.45" cy="84.59" r="1"/>
-            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Antrim / County Down">
-          <g id="Belfast">
-            <circle cx="36.41" cy="80.88" r="1"/>
-            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lisburn">
-            <circle cx="34.64" cy="81.71" r="1"/>
-            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bangor, County Down">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -573,9 +471,7 @@
 --
 
 <style>
-  [id='Cities'] > :not([id='{{MacroLocation}}']),
-  [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
-  [id='Bodies of Water'] {
+  [id='Cities'] > :not([id='{{Location}}']), [id='Bodies of Water'] {
     visibility: hidden;
   }
   [id='{{City}}'].cityCounty {
@@ -756,385 +652,285 @@
       </g>
     </g>
     <g id="Cities">
-      <g id="Somerset">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Bath">
+        <circle cx="63.13" cy="119.28" r="1"/>
+        <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cornwall">
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Truro">
+        <circle cx="42.77" cy="132.85" r="1"/>
+        <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Decon">
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Plymouth">
+        <circle cx="50.12" cy="130.59" r="1"/>
+        <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Wiltshire">
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Exeter">
+        <circle cx="54.08" cy="127.2" r="1"/>
+        <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Hampshire">
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wells">
+        <circle cx="60.87" cy="120.41" r="1"/>
+        <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Sussex">
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Salisbury">
+        <circle cx="67.66" cy="122.1" r="1"/>
+        <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="East Sussex">
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Southampton">
+        <circle cx="71.5" cy="125" r="1"/>
+        <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Kent">
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Portsmouth">
+        <circle cx="73.5" cy="125.5" r="1"/>
+        <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Greater London">
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chichester">
+        <circle cx="75.58" cy="124.93" r="1"/>
+        <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Oxfordshire">
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Winchester">
+        <circle cx="72.3" cy="122.1" r="1"/>
+        <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Hertfordshire">
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Brighton and Hove">
+        <circle cx="80.67" cy="124.93" r="1"/>
+        <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Essex">
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Colchester">
-          <circle cx="88.03" cy="112.06" r="1"/>
-          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Southend-on-Sea">
-          <circle cx="86.81" cy="116.72" r="1"/>
-          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Canterbury">
+        <circle cx="89.94" cy="119.84" r="1"/>
+        <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gloucestershire">
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="City of Westminster">
+        <circle cx="79.54" cy="117.01" r="1"/>
+        <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Dyfed">
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Southend-on-Sea">
+        <circle cx="86.81" cy="116.72" r="1"/>
+        <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Herefordshire">
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Oxford">
+        <circle cx="71.62" cy="113.62" r="1"/>
+        <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Worcestershire">
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Albans">
+        <circle cx="78.97" cy="113.62" r="1"/>
+        <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cambridgeshire">
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chelmsford">
+        <circle cx="85.19" cy="113.62" r="1"/>
+        <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Midlands (county)">
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Newport">
+        <circle cx="58.04" cy="115.88" r="1"/>
+        <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g if="Norfolk">
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Cardiff">
+        <circle cx="56.91" cy="117.01" r="1"/>
+        <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Leicestershire">
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Swansea">
+        <circle cx="52.95" cy="114.75" r="1"/>
+        <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Staffordshire">
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Gloucester">
+        <circle cx="64.26" cy="113.05" r="1"/>
+        <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Nottinghamshire">
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Colchester">
+        <circle cx="88.03" cy="112.06" r="1"/>
+        <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Derbyshire">
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Davids">
+        <circle cx="43.67" cy="112.49" r="1"/>
+        <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Lincolnshire">
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Milton Keynes">
+        <circle cx="75.50" cy="110.91" r="1"/>
+        <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="South Yorkshire">
-        <g id="Doncaster">
-          <circle cx="72.613" cy="92.65" r="1"/>
-          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Hereford">
+        <circle cx="61.1" cy="110.79" r="1"/>
+        <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Greater Manchester">
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Worcester">
+        <circle cx="64.83" cy="109.09" r="1"/>
+        <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Merseyside">
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Cambridge">
+        <circle cx="81.23" cy="108.53" r="1"/>
+        <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cheshire">
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Ely">
+        <circle cx="81.57" cy="106.27" r="1"/>
+        <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Clwyd">
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Wrexham">
-          <circle cx="59.30" cy="97.79" r="1"/>
-          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Coventry">
+        <circle cx="69.35" cy="106.27" r="1"/>
+        <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gwynedd">
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Birmingham">
+        <circle cx="67.09" cy="105.14" r="1"/>
+        <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="East Riding of Yorkshire">
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wolverhampton">
+        <circle cx="65.39" cy="104" r="1"/>
+        <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Yorkshire">
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Norwich">
+        <circle cx="89.72" cy="103.44" r="1"/>
+        <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Lancashire">
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Peterborough">
+        <circle cx="78.97" cy="104" r="1"/>
+        <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="North Yorkshire">
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Leicester">
+        <circle cx="72.52" cy="103.44" r="1"/>
+        <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Durham">
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Lichfield">
+        <circle cx="67.88" cy="103.44" r="1"/>
+        <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Tyne and Wear">
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Nottingham">
+        <circle cx="72.52" cy="100.04" r="1"/>
+        <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Cumbria">
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Derby">
+        <circle cx="69.92" cy="99.48" r="1"/>
+        <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Buckinghamshire">
-        <g id="Milton Keynes">
-          <circle cx="75.50" cy="110.91" r="1"/>
-          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Stoke-on-Trent">
+        <circle cx="65.39" cy="98.91" r="1"/>
+        <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Gwent (county)">
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Lincoln">
+        <circle cx="77.27" cy="97.78" r="1"/>
+        <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="South Glamorgan">
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Sheffield">
+        <circle cx="69.35" cy="94.39" r="1"/>
+        <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="West Glamorgan">
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Doncaster">
+        <circle cx="72.613" cy="92.65" r="1"/>
+        <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Stirling (council area)">
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Manchester">
+        <circle cx="64.83" cy="93.26" r="1"/>
+        <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Perth and Kinross">
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Salford">
+        <circle cx="63.92" cy="93.48" r="1"/>
+        <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Highland (council area)">
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Liverpool">
+        <circle cx="59.17" cy="94.39" r="1"/>
+        <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="Fife">
-        <g id="Dunfermline">
-          <circle cx="55.61" cy="61.85" r="1"/>
-          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Chester">
+        <circle cx="60.3" cy="96.65" r="1"/>
+        <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Down">
-        <g id="Bangor">
-          <circle cx="39.00" cy="79.86" r="1"/>
-          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="St Asaph">
+        <circle cx="56.91" cy="96.65" r="1"/>
+        <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Londonderry">
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wrexham">
+        <circle cx="59.30" cy="97.79" r="1"/>
+        <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Armagh / County Down">
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Bangor, Gwynedd">
+        <circle cx="50.69" cy="96.65" r="1"/>
+        <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Armagh">
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Kingston upon Hull">
+        <circle cx="78.4" cy="89.3" r="1"/>
+        <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
-      <g id="County Antrim / County Down">
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
+      <g id="Wakefield">
+        <circle cx="70.49" cy="90.99" r="1"/>
+        <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Leeds">
+        <circle cx="69.35" cy="89.3" r="1"/>
+        <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bradford">
+        <circle cx="67.09" cy="89.3" r="1"/>
+        <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Preston">
+        <circle cx="61.43" cy="89.3" r="1"/>
+        <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lancaster">
+        <circle cx="61.43" cy="86.47" r="1"/>
+        <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="York">
+        <circle cx="72.75" cy="87.6" r="1"/>
+        <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Ripon">
+        <circle cx="69.92" cy="85.34" r="1"/>
+        <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Durham">
+        <circle cx="69.35" cy="78.55" r="1"/>
+        <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Sunderland">
+        <circle cx="69.92" cy="76.29" r="1"/>
+        <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newcastle upon Tyne">
+        <circle cx="68.79" cy="75.15" r="1"/>
+        <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Carlisle">
+        <circle cx="60.3" cy="75.72" r="1"/>
+        <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Dunfermline">
+        <circle cx="55.61" cy="61.85" r="1"/>
+        <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Stirling">
+        <circle cx="51.35" cy="61.00" r="1"/>
+        <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Perth">
+        <circle cx="54.72" cy="58.42" r="1"/>
+        <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Inverness">
+        <circle cx="49.39" cy="44.2" r="1"/>
+        <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Derry">
+        <circle cx="27.11" cy="75.92" r="1"/>
+        <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Newry">
+        <circle cx="33.87" cy="86.58" r="1"/>
+        <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Bangor, County Down">
+        <circle cx="39.00" cy="79.86" r="1"/>
+        <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Armagh">
+        <circle cx="31.45" cy="84.59" r="1"/>
+        <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Belfast">
+        <circle cx="36.41" cy="80.88" r="1"/>
+        <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+      </g>
+      <g id="Lisburn">
+        <circle cx="34.64" cy="81.71" r="1"/>
+        <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
       </g>
     </g>
     <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/Map - City.html
+++ b/src/note_models/UK_Geog/templates/Map - City.html
@@ -585,12 +585,20 @@
     animation: jump 0.75s;
     animation-iteration-count: infinite;
   }
+  .info {
+    max-width: 30em;
+    margin: 0.75em auto;
+    color: #333;
+    font-size: 90%;
+    font-style: italic;
+  }
 </style>
 
 
 <header>
   <div class="type">City?</div>
   <div class="center">{{type:City}}</div>
+  {{#Info}}<div class="info">{{Info}}</div>{{/Info}}
 
   <hr>
 

--- a/src/note_models/UK_Geog/templates/Map - County.html
+++ b/src/note_models/UK_Geog/templates/Map - County.html
@@ -176,257 +176,351 @@
           </g>
         </g>
         <g id="Cities">
-          <g id="Bath">
-            <circle cx="63.13" cy="119.28" r="1"/>
-            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Somerset">
+            <g id="Bath">
+              <circle cx="63.13" cy="119.28" r="1"/>
+              <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Wells">
+              <circle cx="60.87" cy="120.41" r="1"/>
+              <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Truro">
-            <circle cx="42.77" cy="132.85" r="1"/>
-            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cornwall">
+            <g id="Truro">
+              <circle cx="42.77" cy="132.85" r="1"/>
+              <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Plymouth">
-            <circle cx="50.12" cy="130.59" r="1"/>
-            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Decon">
+            <g id="Plymouth">
+              <circle cx="50.12" cy="130.59" r="1"/>
+              <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Exeter">
+              <circle cx="54.08" cy="127.2" r="1"/>
+              <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Exeter">
-            <circle cx="54.08" cy="127.2" r="1"/>
-            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Wiltshire">
+            <g id="Salisbury">
+              <circle cx="67.66" cy="122.1" r="1"/>
+              <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Wells">
-            <circle cx="60.87" cy="120.41" r="1"/>
-            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Hampshire">
+            <g id="Southampton">
+              <circle cx="71.5" cy="125" r="1"/>
+              <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Portsmouth">
+              <circle cx="73.5" cy="125.5" r="1"/>
+              <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Winchester">
+              <circle cx="72.3" cy="122.1" r="1"/>
+              <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Salisbury">
-            <circle cx="67.66" cy="122.1" r="1"/>
-            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Sussex">
+            <g id="Chichester">
+              <circle cx="75.58" cy="124.93" r="1"/>
+              <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Southampton">
-            <circle cx="71.5" cy="125" r="1"/>
-            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="East Sussex">
+            <g id="Brighton and Hove">
+              <circle cx="80.67" cy="124.93" r="1"/>
+              <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Portsmouth">
-            <circle cx="73.5" cy="125.5" r="1"/>
-            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Kent">
+            <g id="Canterbury">
+              <circle cx="89.94" cy="119.84" r="1"/>
+              <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Chichester">
-            <circle cx="75.58" cy="124.93" r="1"/>
-            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Greater London">
+            <g id="City of Westminster">
+              <circle cx="79.54" cy="117.01" r="1"/>
+              <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Winchester">
-            <circle cx="72.3" cy="122.1" r="1"/>
-            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Oxfordshire">
+            <g id="Oxford">
+              <circle cx="71.62" cy="113.62" r="1"/>
+              <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Brighton and Hove">
-            <circle cx="80.67" cy="124.93" r="1"/>
-            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Hertfordshire">
+            <g id="St Albans">
+              <circle cx="78.97" cy="113.62" r="1"/>
+              <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Canterbury">
-            <circle cx="89.94" cy="119.84" r="1"/>
-            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Essex">
+            <g id="Chelmsford">
+              <circle cx="85.19" cy="113.62" r="1"/>
+              <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="City of Westminster">
-            <circle cx="79.54" cy="117.01" r="1"/>
-            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Gloucestershire">
+            <g id="Gloucester">
+              <circle cx="64.26" cy="113.05" r="1"/>
+              <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Oxford">
-            <circle cx="71.62" cy="113.62" r="1"/>
-            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Dyfed">
+            <g id="St Davids">
+              <circle cx="43.67" cy="112.49" r="1"/>
+              <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="St Albans">
-            <circle cx="78.97" cy="113.62" r="1"/>
-            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Herefordshire">
+            <g id="Hereford">
+              <circle cx="61.1" cy="110.79" r="1"/>
+              <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Chelmsford">
-            <circle cx="85.19" cy="113.62" r="1"/>
-            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Worcestershire">
+            <g id="Worcester">
+              <circle cx="64.83" cy="109.09" r="1"/>
+              <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Newport">
-            <circle cx="58.04" cy="115.88" r="1"/>
-            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cambridgeshire">
+            <g id="Cambridge">
+              <circle cx="81.23" cy="108.53" r="1"/>
+              <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Ely">
+              <circle cx="81.57" cy="106.27" r="1"/>
+              <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Peterborough">
+              <circle cx="78.97" cy="104" r="1"/>
+              <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Cardiff">
-            <circle cx="56.91" cy="117.01" r="1"/>
-            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Midlands (county)">
+            <g id="Coventry">
+              <circle cx="69.35" cy="106.27" r="1"/>
+              <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Birmingham">
+              <circle cx="67.09" cy="105.14" r="1"/>
+              <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Wolverhampton">
+              <circle cx="65.39" cy="104" r="1"/>
+              <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Swansea">
-            <circle cx="52.95" cy="114.75" r="1"/>
-            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g if="Norfolk">
+            <g id="Norwich">
+              <circle cx="89.72" cy="103.44" r="1"/>
+              <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Gloucester">
-            <circle cx="64.26" cy="113.05" r="1"/>
-            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Leicestershire">
+            <g id="Leicester">
+              <circle cx="72.52" cy="103.44" r="1"/>
+              <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="St Davids">
-            <circle cx="43.67" cy="112.49" r="1"/>
-            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Staffordshire">
+            <g id="Lichfield">
+              <circle cx="67.88" cy="103.44" r="1"/>
+              <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Stoke-on-Trent">
+              <circle cx="65.39" cy="98.91" r="1"/>
+              <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Hereford">
-            <circle cx="61.1" cy="110.79" r="1"/>
-            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Nottinghamshire">
+            <g id="Nottingham">
+              <circle cx="72.52" cy="100.04" r="1"/>
+              <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Worcester">
-            <circle cx="64.83" cy="109.09" r="1"/>
-            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Derbyshire">
+            <g id="Derby">
+              <circle cx="69.92" cy="99.48" r="1"/>
+              <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Cambridge">
-            <circle cx="81.23" cy="108.53" r="1"/>
-            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Lincolnshire">
+            <g id="Lincoln">
+              <circle cx="77.27" cy="97.78" r="1"/>
+              <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Ely">
-            <circle cx="81.57" cy="106.27" r="1"/>
-            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="South Yorkshire">
+            <g id="Sheffield">
+              <circle cx="69.35" cy="94.39" r="1"/>
+              <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Coventry">
-            <circle cx="69.35" cy="106.27" r="1"/>
-            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Greater Manchester">
+            <g id="Manchester">
+              <circle cx="64.83" cy="93.26" r="1"/>
+              <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Salford">
+              <circle cx="63.92" cy="93.48" r="1"/>
+              <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Birmingham">
-            <circle cx="67.09" cy="105.14" r="1"/>
-            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Merseyside">
+            <g id="Liverpool">
+              <circle cx="59.17" cy="94.39" r="1"/>
+              <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Wolverhampton">
-            <circle cx="65.39" cy="104" r="1"/>
-            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cheshire">
+            <g id="Chester">
+              <circle cx="60.3" cy="96.65" r="1"/>
+              <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Norwich">
-            <circle cx="89.72" cy="103.44" r="1"/>
-            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Clwyd">
+            <g id="St Asaph">
+              <circle cx="56.91" cy="96.65" r="1"/>
+              <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Peterborough">
-            <circle cx="78.97" cy="104" r="1"/>
-            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Gwynedd">
+            <g id="Bangor">
+              <circle cx="50.69" cy="96.65" r="1"/>
+              <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Leicester">
-            <circle cx="72.52" cy="103.44" r="1"/>
-            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="East Riding of Yorkshire">
+            <g id="Kingston upon Hull">
+              <circle cx="78.4" cy="89.3" r="1"/>
+              <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Lichfield">
-            <circle cx="67.88" cy="103.44" r="1"/>
-            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Yorkshire">
+            <g id="Wakefield">
+              <circle cx="70.49" cy="90.99" r="1"/>
+              <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Leeds">
+              <circle cx="69.35" cy="89.3" r="1"/>
+              <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Bradford">
+              <circle cx="67.09" cy="89.3" r="1"/>
+              <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Nottingham">
-            <circle cx="72.52" cy="100.04" r="1"/>
-            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Lancashire">
+            <g id="Preston">
+              <circle cx="61.43" cy="89.3" r="1"/>
+              <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Lancaster">
+              <circle cx="61.43" cy="86.47" r="1"/>
+              <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Derby">
-            <circle cx="69.92" cy="99.48" r="1"/>
-            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="North Yorkshire">
+            <g id="York">
+              <circle cx="72.75" cy="87.6" r="1"/>
+              <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Ripon">
+              <circle cx="69.92" cy="85.34" r="1"/>
+              <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Stoke-on-Trent">
-            <circle cx="65.39" cy="98.91" r="1"/>
-            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Durham">
+            <g id="Durham">
+              <circle cx="69.35" cy="78.55" r="1"/>
+              <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Lincoln">
-            <circle cx="77.27" cy="97.78" r="1"/>
-            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Tyne and Wear">
+            <g id="Sunderland">
+              <circle cx="69.92" cy="76.29" r="1"/>
+              <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Newcastle upon Tyne">
+              <circle cx="68.79" cy="75.15" r="1"/>
+              <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Sheffield">
-            <circle cx="69.35" cy="94.39" r="1"/>
-            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Cumbria">
+            <g id="Carlisle">
+              <circle cx="60.3" cy="75.72" r="1"/>
+              <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Manchester">
-            <circle cx="64.83" cy="93.26" r="1"/>
-            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Gwent (county)">
+            <g id="Newport">
+              <circle cx="58.04" cy="115.88" r="1"/>
+              <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Salford">
-            <circle cx="63.92" cy="93.48" r="1"/>
-            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="South Glamorgan">
+            <g id="Cardiff">
+              <circle cx="56.91" cy="117.01" r="1"/>
+              <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Liverpool">
-            <circle cx="59.17" cy="94.39" r="1"/>
-            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="West Glamorgan">
+            <g id="Swansea">
+              <circle cx="52.95" cy="114.75" r="1"/>
+              <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Chester">
-            <circle cx="60.3" cy="96.65" r="1"/>
-            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Stirling (council area)">
+            <g id="Stirling">
+              <circle cx="51.35" cy="61.00" r="1"/>
+              <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="St Asaph">
-            <circle cx="56.91" cy="96.65" r="1"/>
-            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Perth and Kinross">
+            <g id="Perth">
+              <circle cx="54.72" cy="58.42" r="1"/>
+              <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Bangor">
-            <circle cx="50.69" cy="96.65" r="1"/>
-            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="Highland (council area)">
+            <g id="Inverness">
+              <circle cx="49.39" cy="44.2" r="1"/>
+              <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Kingston upon Hull">
-            <circle cx="78.4" cy="89.3" r="1"/>
-            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Londonderry">
+            <g id="Derry">
+              <circle cx="27.11" cy="75.92" r="1"/>
+              <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Wakefield">
-            <circle cx="70.49" cy="90.99" r="1"/>
-            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Armagh / County Down">
+            <g id="Newry">
+              <circle cx="33.87" cy="86.58" r="1"/>
+              <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Leeds">
-            <circle cx="69.35" cy="89.3" r="1"/>
-            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Armagh">
+            <g id="Armagh">
+              <circle cx="31.45" cy="84.59" r="1"/>
+              <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
-          <g id="Bradford">
-            <circle cx="67.09" cy="89.3" r="1"/>
-            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Preston">
-            <circle cx="61.43" cy="89.3" r="1"/>
-            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lancaster">
-            <circle cx="61.43" cy="86.47" r="1"/>
-            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="York">
-            <circle cx="72.75" cy="87.6" r="1"/>
-            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ripon">
-            <circle cx="69.92" cy="85.34" r="1"/>
-            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Durham">
-            <circle cx="69.35" cy="78.55" r="1"/>
-            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Sunderland">
-            <circle cx="69.92" cy="76.29" r="1"/>
-            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newcastle upon Tyne">
-            <circle cx="68.79" cy="75.15" r="1"/>
-            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Carlisle">
-            <circle cx="60.3" cy="75.72" r="1"/>
-            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Stirling">
-            <circle cx="51.35" cy="61.00" r="1"/>
-            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Perth">
-            <circle cx="54.72" cy="58.42" r="1"/>
-            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Inverness">
-            <circle cx="49.39" cy="44.2" r="1"/>
-            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Derry">
-            <circle cx="27.11" cy="75.92" r="1"/>
-            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newry">
-            <circle cx="33.87" cy="86.58" r="1"/>
-            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Armagh">
-            <circle cx="31.45" cy="84.59" r="1"/>
-            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Belfast">
-            <circle cx="36.41" cy="80.88" r="1"/>
-            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lisburn">
-            <circle cx="34.64" cy="81.71" r="1"/>
-            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          <g id="County Antrim / County Down">
+            <g id="Belfast">
+              <circle cx="36.41" cy="80.88" r="1"/>
+              <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Lisburn">
+              <circle cx="34.64" cy="81.71" r="1"/>
+              <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
         </g>
         <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -631,257 +725,351 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Bath">
-          <circle cx="63.13" cy="119.28" r="1"/>
-          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Somerset">
+          <g id="Bath">
+            <circle cx="63.13" cy="119.28" r="1"/>
+            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wells">
+            <circle cx="60.87" cy="120.41" r="1"/>
+            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Truro">
-          <circle cx="42.77" cy="132.85" r="1"/>
-          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cornwall">
+          <g id="Truro">
+            <circle cx="42.77" cy="132.85" r="1"/>
+            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Plymouth">
-          <circle cx="50.12" cy="130.59" r="1"/>
-          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Decon">
+          <g id="Plymouth">
+            <circle cx="50.12" cy="130.59" r="1"/>
+            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Exeter">
+            <circle cx="54.08" cy="127.2" r="1"/>
+            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Exeter">
-          <circle cx="54.08" cy="127.2" r="1"/>
-          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Wiltshire">
+          <g id="Salisbury">
+            <circle cx="67.66" cy="122.1" r="1"/>
+            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wells">
-          <circle cx="60.87" cy="120.41" r="1"/>
-          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hampshire">
+          <g id="Southampton">
+            <circle cx="71.5" cy="125" r="1"/>
+            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Portsmouth">
+            <circle cx="73.5" cy="125.5" r="1"/>
+            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Winchester">
+            <circle cx="72.3" cy="122.1" r="1"/>
+            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salisbury">
-          <circle cx="67.66" cy="122.1" r="1"/>
-          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Sussex">
+          <g id="Chichester">
+            <circle cx="75.58" cy="124.93" r="1"/>
+            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Southampton">
-          <circle cx="71.5" cy="125" r="1"/>
-          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Sussex">
+          <g id="Brighton and Hove">
+            <circle cx="80.67" cy="124.93" r="1"/>
+            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Portsmouth">
-          <circle cx="73.5" cy="125.5" r="1"/>
-          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Kent">
+          <g id="Canterbury">
+            <circle cx="89.94" cy="119.84" r="1"/>
+            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chichester">
-          <circle cx="75.58" cy="124.93" r="1"/>
-          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater London">
+          <g id="City of Westminster">
+            <circle cx="79.54" cy="117.01" r="1"/>
+            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Winchester">
-          <circle cx="72.3" cy="122.1" r="1"/>
-          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Oxfordshire">
+          <g id="Oxford">
+            <circle cx="71.62" cy="113.62" r="1"/>
+            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Brighton and Hove">
-          <circle cx="80.67" cy="124.93" r="1"/>
-          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Hertfordshire">
+          <g id="St Albans">
+            <circle cx="78.97" cy="113.62" r="1"/>
+            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Canterbury">
-          <circle cx="89.94" cy="119.84" r="1"/>
-          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Essex">
+          <g id="Chelmsford">
+            <circle cx="85.19" cy="113.62" r="1"/>
+            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="City of Westminster">
-          <circle cx="79.54" cy="117.01" r="1"/>
-          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gloucestershire">
+          <g id="Gloucester">
+            <circle cx="64.26" cy="113.05" r="1"/>
+            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Oxford">
-          <circle cx="71.62" cy="113.62" r="1"/>
-          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Dyfed">
+          <g id="St Davids">
+            <circle cx="43.67" cy="112.49" r="1"/>
+            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Albans">
-          <circle cx="78.97" cy="113.62" r="1"/>
-          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Herefordshire">
+          <g id="Hereford">
+            <circle cx="61.1" cy="110.79" r="1"/>
+            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chelmsford">
-          <circle cx="85.19" cy="113.62" r="1"/>
-          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Worcestershire">
+          <g id="Worcester">
+            <circle cx="64.83" cy="109.09" r="1"/>
+            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Newport">
-          <circle cx="58.04" cy="115.88" r="1"/>
-          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cambridgeshire">
+          <g id="Cambridge">
+            <circle cx="81.23" cy="108.53" r="1"/>
+            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ely">
+            <circle cx="81.57" cy="106.27" r="1"/>
+            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Peterborough">
+            <circle cx="78.97" cy="104" r="1"/>
+            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cardiff">
-          <circle cx="56.91" cy="117.01" r="1"/>
-          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Midlands (county)">
+          <g id="Coventry">
+            <circle cx="69.35" cy="106.27" r="1"/>
+            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Birmingham">
+            <circle cx="67.09" cy="105.14" r="1"/>
+            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wolverhampton">
+            <circle cx="65.39" cy="104" r="1"/>
+            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Swansea">
-          <circle cx="52.95" cy="114.75" r="1"/>
-          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g if="Norfolk">
+          <g id="Norwich">
+            <circle cx="89.72" cy="103.44" r="1"/>
+            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Gloucester">
-          <circle cx="64.26" cy="113.05" r="1"/>
-          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Leicestershire">
+          <g id="Leicester">
+            <circle cx="72.52" cy="103.44" r="1"/>
+            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Davids">
-          <circle cx="43.67" cy="112.49" r="1"/>
-          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Staffordshire">
+          <g id="Lichfield">
+            <circle cx="67.88" cy="103.44" r="1"/>
+            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Stoke-on-Trent">
+            <circle cx="65.39" cy="98.91" r="1"/>
+            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Hereford">
-          <circle cx="61.1" cy="110.79" r="1"/>
-          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Nottinghamshire">
+          <g id="Nottingham">
+            <circle cx="72.52" cy="100.04" r="1"/>
+            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Worcester">
-          <circle cx="64.83" cy="109.09" r="1"/>
-          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Derbyshire">
+          <g id="Derby">
+            <circle cx="69.92" cy="99.48" r="1"/>
+            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Cambridge">
-          <circle cx="81.23" cy="108.53" r="1"/>
-          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lincolnshire">
+          <g id="Lincoln">
+            <circle cx="77.27" cy="97.78" r="1"/>
+            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Ely">
-          <circle cx="81.57" cy="106.27" r="1"/>
-          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Yorkshire">
+          <g id="Sheffield">
+            <circle cx="69.35" cy="94.39" r="1"/>
+            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Coventry">
-          <circle cx="69.35" cy="106.27" r="1"/>
-          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Greater Manchester">
+          <g id="Manchester">
+            <circle cx="64.83" cy="93.26" r="1"/>
+            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Salford">
+            <circle cx="63.92" cy="93.48" r="1"/>
+            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Birmingham">
-          <circle cx="67.09" cy="105.14" r="1"/>
-          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Merseyside">
+          <g id="Liverpool">
+            <circle cx="59.17" cy="94.39" r="1"/>
+            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wolverhampton">
-          <circle cx="65.39" cy="104" r="1"/>
-          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cheshire">
+          <g id="Chester">
+            <circle cx="60.3" cy="96.65" r="1"/>
+            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Norwich">
-          <circle cx="89.72" cy="103.44" r="1"/>
-          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Clwyd">
+          <g id="St Asaph">
+            <circle cx="56.91" cy="96.65" r="1"/>
+            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Peterborough">
-          <circle cx="78.97" cy="104" r="1"/>
-          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwynedd">
+          <g id="Bangor">
+            <circle cx="50.69" cy="96.65" r="1"/>
+            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leicester">
-          <circle cx="72.52" cy="103.44" r="1"/>
-          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="East Riding of Yorkshire">
+          <g id="Kingston upon Hull">
+            <circle cx="78.4" cy="89.3" r="1"/>
+            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lichfield">
-          <circle cx="67.88" cy="103.44" r="1"/>
-          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Yorkshire">
+          <g id="Wakefield">
+            <circle cx="70.49" cy="90.99" r="1"/>
+            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Leeds">
+            <circle cx="69.35" cy="89.3" r="1"/>
+            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bradford">
+            <circle cx="67.09" cy="89.3" r="1"/>
+            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Nottingham">
-          <circle cx="72.52" cy="100.04" r="1"/>
-          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Lancashire">
+          <g id="Preston">
+            <circle cx="61.43" cy="89.3" r="1"/>
+            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lancaster">
+            <circle cx="61.43" cy="86.47" r="1"/>
+            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Derby">
-          <circle cx="69.92" cy="99.48" r="1"/>
-          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="North Yorkshire">
+          <g id="York">
+            <circle cx="72.75" cy="87.6" r="1"/>
+            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ripon">
+            <circle cx="69.92" cy="85.34" r="1"/>
+            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Stoke-on-Trent">
-          <circle cx="65.39" cy="98.91" r="1"/>
-          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Durham">
+          <g id="Durham">
+            <circle cx="69.35" cy="78.55" r="1"/>
+            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Lincoln">
-          <circle cx="77.27" cy="97.78" r="1"/>
-          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Tyne and Wear">
+          <g id="Sunderland">
+            <circle cx="69.92" cy="76.29" r="1"/>
+            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newcastle upon Tyne">
+            <circle cx="68.79" cy="75.15" r="1"/>
+            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Sheffield">
-          <circle cx="69.35" cy="94.39" r="1"/>
-          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Cumbria">
+          <g id="Carlisle">
+            <circle cx="60.3" cy="75.72" r="1"/>
+            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Manchester">
-          <circle cx="64.83" cy="93.26" r="1"/>
-          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Gwent (county)">
+          <g id="Newport">
+            <circle cx="58.04" cy="115.88" r="1"/>
+            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Salford">
-          <circle cx="63.92" cy="93.48" r="1"/>
-          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="South Glamorgan">
+          <g id="Cardiff">
+            <circle cx="56.91" cy="117.01" r="1"/>
+            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Liverpool">
-          <circle cx="59.17" cy="94.39" r="1"/>
-          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="West Glamorgan">
+          <g id="Swansea">
+            <circle cx="52.95" cy="114.75" r="1"/>
+            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Chester">
-          <circle cx="60.3" cy="96.65" r="1"/>
-          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Stirling (council area)">
+          <g id="Stirling">
+            <circle cx="51.35" cy="61.00" r="1"/>
+            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="St Asaph">
-          <circle cx="56.91" cy="96.65" r="1"/>
-          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Perth and Kinross">
+          <g id="Perth">
+            <circle cx="54.72" cy="58.42" r="1"/>
+            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bangor">
-          <circle cx="50.69" cy="96.65" r="1"/>
-          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="Highland (council area)">
+          <g id="Inverness">
+            <circle cx="49.39" cy="44.2" r="1"/>
+            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Kingston upon Hull">
-          <circle cx="78.4" cy="89.3" r="1"/>
-          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Londonderry">
+          <g id="Derry">
+            <circle cx="27.11" cy="75.92" r="1"/>
+            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Wakefield">
-          <circle cx="70.49" cy="90.99" r="1"/>
-          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh / County Down">
+          <g id="Newry">
+            <circle cx="33.87" cy="86.58" r="1"/>
+            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Leeds">
-          <circle cx="69.35" cy="89.3" r="1"/>
-          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Armagh">
+          <g id="Armagh">
+            <circle cx="31.45" cy="84.59" r="1"/>
+            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
-        <g id="Bradford">
-          <circle cx="67.09" cy="89.3" r="1"/>
-          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Preston">
-          <circle cx="61.43" cy="89.3" r="1"/>
-          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lancaster">
-          <circle cx="61.43" cy="86.47" r="1"/>
-          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="York">
-          <circle cx="72.75" cy="87.6" r="1"/>
-          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Ripon">
-          <circle cx="69.92" cy="85.34" r="1"/>
-          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Durham">
-          <circle cx="69.35" cy="78.55" r="1"/>
-          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Sunderland">
-          <circle cx="69.92" cy="76.29" r="1"/>
-          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newcastle upon Tyne">
-          <circle cx="68.79" cy="75.15" r="1"/>
-          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Carlisle">
-          <circle cx="60.3" cy="75.72" r="1"/>
-          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Stirling">
-          <circle cx="51.35" cy="61.00" r="1"/>
-          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Perth">
-          <circle cx="54.72" cy="58.42" r="1"/>
-          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Inverness">
-          <circle cx="49.39" cy="44.2" r="1"/>
-          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Derry">
-          <circle cx="27.11" cy="75.92" r="1"/>
-          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Newry">
-          <circle cx="33.87" cy="86.58" r="1"/>
-          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Armagh">
-          <circle cx="31.45" cy="84.59" r="1"/>
-          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Belfast">
-          <circle cx="36.41" cy="80.88" r="1"/>
-          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-        </g>
-        <g id="Lisburn">
-          <circle cx="34.64" cy="81.71" r="1"/>
-          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        <g id="County Antrim / County Down">
+          <g id="Belfast">
+            <circle cx="36.41" cy="80.88" r="1"/>
+            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lisburn">
+            <circle cx="34.64" cy="81.71" r="1"/>
+            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/Map - County.html
+++ b/src/note_models/UK_Geog/templates/Map - County.html
@@ -176,385 +176,285 @@
           </g>
         </g>
         <g id="Cities">
-          <g id="Somerset">
-            <g id="Bath">
-              <circle cx="63.13" cy="119.28" r="1"/>
-              <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Wells">
-              <circle cx="60.87" cy="120.41" r="1"/>
-              <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Bath">
+            <circle cx="63.13" cy="119.28" r="1"/>
+            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cornwall">
-            <g id="Truro">
-              <circle cx="42.77" cy="132.85" r="1"/>
-              <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Truro">
+            <circle cx="42.77" cy="132.85" r="1"/>
+            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Decon">
-            <g id="Plymouth">
-              <circle cx="50.12" cy="130.59" r="1"/>
-              <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Exeter">
-              <circle cx="54.08" cy="127.2" r="1"/>
-              <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Plymouth">
+            <circle cx="50.12" cy="130.59" r="1"/>
+            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Wiltshire">
-            <g id="Salisbury">
-              <circle cx="67.66" cy="122.1" r="1"/>
-              <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Exeter">
+            <circle cx="54.08" cy="127.2" r="1"/>
+            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Hampshire">
-            <g id="Southampton">
-              <circle cx="71.5" cy="125" r="1"/>
-              <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Portsmouth">
-              <circle cx="73.5" cy="125.5" r="1"/>
-              <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Winchester">
-              <circle cx="72.3" cy="122.1" r="1"/>
-              <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wells">
+            <circle cx="60.87" cy="120.41" r="1"/>
+            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Sussex">
-            <g id="Chichester">
-              <circle cx="75.58" cy="124.93" r="1"/>
-              <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Salisbury">
+            <circle cx="67.66" cy="122.1" r="1"/>
+            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="East Sussex">
-            <g id="Brighton and Hove">
-              <circle cx="80.67" cy="124.93" r="1"/>
-              <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Southampton">
+            <circle cx="71.5" cy="125" r="1"/>
+            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Kent">
-            <g id="Canterbury">
-              <circle cx="89.94" cy="119.84" r="1"/>
-              <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Portsmouth">
+            <circle cx="73.5" cy="125.5" r="1"/>
+            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Greater London">
-            <g id="City of Westminster">
-              <circle cx="79.54" cy="117.01" r="1"/>
-              <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Chichester">
+            <circle cx="75.58" cy="124.93" r="1"/>
+            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Oxfordshire">
-            <g id="Oxford">
-              <circle cx="71.62" cy="113.62" r="1"/>
-              <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Winchester">
+            <circle cx="72.3" cy="122.1" r="1"/>
+            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Hertfordshire">
-            <g id="St Albans">
-              <circle cx="78.97" cy="113.62" r="1"/>
-              <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Brighton and Hove">
+            <circle cx="80.67" cy="124.93" r="1"/>
+            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Essex">
-            <g id="Chelmsford">
-              <circle cx="85.19" cy="113.62" r="1"/>
-              <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Colchester">
-              <circle cx="88.03" cy="112.06" r="1"/>
-              <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Southend-on-Sea">
-              <circle cx="86.81" cy="116.72" r="1"/>
-              <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Canterbury">
+            <circle cx="89.94" cy="119.84" r="1"/>
+            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Gloucestershire">
-            <g id="Gloucester">
-              <circle cx="64.26" cy="113.05" r="1"/>
-              <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="City of Westminster">
+            <circle cx="79.54" cy="117.01" r="1"/>
+            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Dyfed">
-            <g id="St Davids">
-              <circle cx="43.67" cy="112.49" r="1"/>
-              <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Southend-on-Sea">
+            <circle cx="86.81" cy="116.72" r="1"/>
+            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Herefordshire">
-            <g id="Hereford">
-              <circle cx="61.1" cy="110.79" r="1"/>
-              <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Oxford">
+            <circle cx="71.62" cy="113.62" r="1"/>
+            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Worcestershire">
-            <g id="Worcester">
-              <circle cx="64.83" cy="109.09" r="1"/>
-              <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="St Albans">
+            <circle cx="78.97" cy="113.62" r="1"/>
+            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cambridgeshire">
-            <g id="Cambridge">
-              <circle cx="81.23" cy="108.53" r="1"/>
-              <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Ely">
-              <circle cx="81.57" cy="106.27" r="1"/>
-              <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Peterborough">
-              <circle cx="78.97" cy="104" r="1"/>
-              <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Chelmsford">
+            <circle cx="85.19" cy="113.62" r="1"/>
+            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Midlands (county)">
-            <g id="Coventry">
-              <circle cx="69.35" cy="106.27" r="1"/>
-              <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Birmingham">
-              <circle cx="67.09" cy="105.14" r="1"/>
-              <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Wolverhampton">
-              <circle cx="65.39" cy="104" r="1"/>
-              <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Newport">
+            <circle cx="58.04" cy="115.88" r="1"/>
+            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g if="Norfolk">
-            <g id="Norwich">
-              <circle cx="89.72" cy="103.44" r="1"/>
-              <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Cardiff">
+            <circle cx="56.91" cy="117.01" r="1"/>
+            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Leicestershire">
-            <g id="Leicester">
-              <circle cx="72.52" cy="103.44" r="1"/>
-              <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Swansea">
+            <circle cx="52.95" cy="114.75" r="1"/>
+            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Staffordshire">
-            <g id="Lichfield">
-              <circle cx="67.88" cy="103.44" r="1"/>
-              <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Stoke-on-Trent">
-              <circle cx="65.39" cy="98.91" r="1"/>
-              <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Gloucester">
+            <circle cx="64.26" cy="113.05" r="1"/>
+            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Nottinghamshire">
-            <g id="Nottingham">
-              <circle cx="72.52" cy="100.04" r="1"/>
-              <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Colchester">
+            <circle cx="88.03" cy="112.06" r="1"/>
+            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Derbyshire">
-            <g id="Derby">
-              <circle cx="69.92" cy="99.48" r="1"/>
-              <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="St Davids">
+            <circle cx="43.67" cy="112.49" r="1"/>
+            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Lincolnshire">
-            <g id="Lincoln">
-              <circle cx="77.27" cy="97.78" r="1"/>
-              <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Milton Keynes">
+            <circle cx="75.50" cy="110.91" r="1"/>
+            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="South Yorkshire">
-            <g id="Doncaster">
-              <circle cx="72.613" cy="92.65" r="1"/>
-              <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Sheffield">
-              <circle cx="69.35" cy="94.39" r="1"/>
-              <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Hereford">
+            <circle cx="61.1" cy="110.79" r="1"/>
+            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Greater Manchester">
-            <g id="Manchester">
-              <circle cx="64.83" cy="93.26" r="1"/>
-              <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Salford">
-              <circle cx="63.92" cy="93.48" r="1"/>
-              <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Worcester">
+            <circle cx="64.83" cy="109.09" r="1"/>
+            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Merseyside">
-            <g id="Liverpool">
-              <circle cx="59.17" cy="94.39" r="1"/>
-              <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Cambridge">
+            <circle cx="81.23" cy="108.53" r="1"/>
+            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cheshire">
-            <g id="Chester">
-              <circle cx="60.3" cy="96.65" r="1"/>
-              <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Ely">
+            <circle cx="81.57" cy="106.27" r="1"/>
+            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Clwyd">
-            <g id="St Asaph">
-              <circle cx="56.91" cy="96.65" r="1"/>
-              <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Wrexham">
-              <circle cx="59.30" cy="97.79" r="1"/>
-              <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Coventry">
+            <circle cx="69.35" cy="106.27" r="1"/>
+            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Gwynedd">
-            <g id="Bangor">
-              <circle cx="50.69" cy="96.65" r="1"/>
-              <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Birmingham">
+            <circle cx="67.09" cy="105.14" r="1"/>
+            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="East Riding of Yorkshire">
-            <g id="Kingston upon Hull">
-              <circle cx="78.4" cy="89.3" r="1"/>
-              <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wolverhampton">
+            <circle cx="65.39" cy="104" r="1"/>
+            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Yorkshire">
-            <g id="Wakefield">
-              <circle cx="70.49" cy="90.99" r="1"/>
-              <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Leeds">
-              <circle cx="69.35" cy="89.3" r="1"/>
-              <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Bradford">
-              <circle cx="67.09" cy="89.3" r="1"/>
-              <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Norwich">
+            <circle cx="89.72" cy="103.44" r="1"/>
+            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Lancashire">
-            <g id="Preston">
-              <circle cx="61.43" cy="89.3" r="1"/>
-              <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Lancaster">
-              <circle cx="61.43" cy="86.47" r="1"/>
-              <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Peterborough">
+            <circle cx="78.97" cy="104" r="1"/>
+            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="North Yorkshire">
-            <g id="York">
-              <circle cx="72.75" cy="87.6" r="1"/>
-              <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Ripon">
-              <circle cx="69.92" cy="85.34" r="1"/>
-              <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Leicester">
+            <circle cx="72.52" cy="103.44" r="1"/>
+            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Durham">
-            <g id="Durham">
-              <circle cx="69.35" cy="78.55" r="1"/>
-              <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Lichfield">
+            <circle cx="67.88" cy="103.44" r="1"/>
+            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Tyne and Wear">
-            <g id="Sunderland">
-              <circle cx="69.92" cy="76.29" r="1"/>
-              <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Newcastle upon Tyne">
-              <circle cx="68.79" cy="75.15" r="1"/>
-              <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Nottingham">
+            <circle cx="72.52" cy="100.04" r="1"/>
+            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Cumbria">
-            <g id="Carlisle">
-              <circle cx="60.3" cy="75.72" r="1"/>
-              <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Derby">
+            <circle cx="69.92" cy="99.48" r="1"/>
+            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Buckinghamshire">
-            <g id="Milton Keynes">
-              <circle cx="75.50" cy="110.91" r="1"/>
-              <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Stoke-on-Trent">
+            <circle cx="65.39" cy="98.91" r="1"/>
+            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Gwent (county)">
-            <g id="Newport">
-              <circle cx="58.04" cy="115.88" r="1"/>
-              <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Lincoln">
+            <circle cx="77.27" cy="97.78" r="1"/>
+            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="South Glamorgan">
-            <g id="Cardiff">
-              <circle cx="56.91" cy="117.01" r="1"/>
-              <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Sheffield">
+            <circle cx="69.35" cy="94.39" r="1"/>
+            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="West Glamorgan">
-            <g id="Swansea">
-              <circle cx="52.95" cy="114.75" r="1"/>
-              <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Doncaster">
+            <circle cx="72.613" cy="92.65" r="1"/>
+            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Stirling (council area)">
-            <g id="Stirling">
-              <circle cx="51.35" cy="61.00" r="1"/>
-              <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Manchester">
+            <circle cx="64.83" cy="93.26" r="1"/>
+            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Perth and Kinross">
-            <g id="Perth">
-              <circle cx="54.72" cy="58.42" r="1"/>
-              <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Salford">
+            <circle cx="63.92" cy="93.48" r="1"/>
+            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Highland (council area)">
-            <g id="Inverness">
-              <circle cx="49.39" cy="44.2" r="1"/>
-              <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Liverpool">
+            <circle cx="59.17" cy="94.39" r="1"/>
+            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="Fife">
-            <g id="Dunfermline">
-              <circle cx="55.61" cy="61.85" r="1"/>
-              <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Chester">
+            <circle cx="60.3" cy="96.65" r="1"/>
+            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Down">
-            <g id="Bangor">
-              <circle cx="39.00" cy="79.86" r="1"/>
-              <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="St Asaph">
+            <circle cx="56.91" cy="96.65" r="1"/>
+            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Londonderry">
-            <g id="Derry">
-              <circle cx="27.11" cy="75.92" r="1"/>
-              <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wrexham">
+            <circle cx="59.30" cy="97.79" r="1"/>
+            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Armagh / County Down">
-            <g id="Newry">
-              <circle cx="33.87" cy="86.58" r="1"/>
-              <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Bangor, Gwynedd">
+            <circle cx="50.69" cy="96.65" r="1"/>
+            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Armagh">
-            <g id="Armagh">
-              <circle cx="31.45" cy="84.59" r="1"/>
-              <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Kingston upon Hull">
+            <circle cx="78.4" cy="89.3" r="1"/>
+            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
-          <g id="County Antrim / County Down">
-            <g id="Belfast">
-              <circle cx="36.41" cy="80.88" r="1"/>
-              <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
-            <g id="Lisburn">
-              <circle cx="34.64" cy="81.71" r="1"/>
-              <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-            </g>
+          <g id="Wakefield">
+            <circle cx="70.49" cy="90.99" r="1"/>
+            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Leeds">
+            <circle cx="69.35" cy="89.3" r="1"/>
+            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bradford">
+            <circle cx="67.09" cy="89.3" r="1"/>
+            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Preston">
+            <circle cx="61.43" cy="89.3" r="1"/>
+            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lancaster">
+            <circle cx="61.43" cy="86.47" r="1"/>
+            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="York">
+            <circle cx="72.75" cy="87.6" r="1"/>
+            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Ripon">
+            <circle cx="69.92" cy="85.34" r="1"/>
+            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Durham">
+            <circle cx="69.35" cy="78.55" r="1"/>
+            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Sunderland">
+            <circle cx="69.92" cy="76.29" r="1"/>
+            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newcastle upon Tyne">
+            <circle cx="68.79" cy="75.15" r="1"/>
+            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Carlisle">
+            <circle cx="60.3" cy="75.72" r="1"/>
+            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Dunfermline">
+            <circle cx="55.61" cy="61.85" r="1"/>
+            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Stirling">
+            <circle cx="51.35" cy="61.00" r="1"/>
+            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Perth">
+            <circle cx="54.72" cy="58.42" r="1"/>
+            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Inverness">
+            <circle cx="49.39" cy="44.2" r="1"/>
+            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Derry">
+            <circle cx="27.11" cy="75.92" r="1"/>
+            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Newry">
+            <circle cx="33.87" cy="86.58" r="1"/>
+            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Bangor, County Down">
+            <circle cx="39.00" cy="79.86" r="1"/>
+            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Armagh">
+            <circle cx="31.45" cy="84.59" r="1"/>
+            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Belfast">
+            <circle cx="36.41" cy="80.88" r="1"/>
+            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Lisburn">
+            <circle cx="34.64" cy="81.71" r="1"/>
+            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>
@@ -759,385 +659,285 @@
         </g>
       </g>
       <g id="Cities">
-        <g id="Somerset">
-          <g id="Bath">
-            <circle cx="63.13" cy="119.28" r="1"/>
-            <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wells">
-            <circle cx="60.87" cy="120.41" r="1"/>
-            <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bath">
+          <circle cx="63.13" cy="119.28" r="1"/>
+          <circle cx="63.13" cy="119.28" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cornwall">
-          <g id="Truro">
-            <circle cx="42.77" cy="132.85" r="1"/>
-            <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Truro">
+          <circle cx="42.77" cy="132.85" r="1"/>
+          <circle cx="42.77" cy="132.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Decon">
-          <g id="Plymouth">
-            <circle cx="50.12" cy="130.59" r="1"/>
-            <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Exeter">
-            <circle cx="54.08" cy="127.2" r="1"/>
-            <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Plymouth">
+          <circle cx="50.12" cy="130.59" r="1"/>
+          <circle cx="50.12" cy="130.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Wiltshire">
-          <g id="Salisbury">
-            <circle cx="67.66" cy="122.1" r="1"/>
-            <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Exeter">
+          <circle cx="54.08" cy="127.2" r="1"/>
+          <circle cx="54.08" cy="127.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hampshire">
-          <g id="Southampton">
-            <circle cx="71.5" cy="125" r="1"/>
-            <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Portsmouth">
-            <circle cx="73.5" cy="125.5" r="1"/>
-            <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Winchester">
-            <circle cx="72.3" cy="122.1" r="1"/>
-            <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wells">
+          <circle cx="60.87" cy="120.41" r="1"/>
+          <circle cx="60.87" cy="120.41" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Sussex">
-          <g id="Chichester">
-            <circle cx="75.58" cy="124.93" r="1"/>
-            <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salisbury">
+          <circle cx="67.66" cy="122.1" r="1"/>
+          <circle cx="67.66" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Sussex">
-          <g id="Brighton and Hove">
-            <circle cx="80.67" cy="124.93" r="1"/>
-            <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southampton">
+          <circle cx="71.5" cy="125" r="1"/>
+          <circle cx="71.5" cy="125" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Kent">
-          <g id="Canterbury">
-            <circle cx="89.94" cy="119.84" r="1"/>
-            <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Portsmouth">
+          <circle cx="73.5" cy="125.5" r="1"/>
+          <circle cx="73.5" cy="125.5" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater London">
-          <g id="City of Westminster">
-            <circle cx="79.54" cy="117.01" r="1"/>
-            <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chichester">
+          <circle cx="75.58" cy="124.93" r="1"/>
+          <circle cx="75.58" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Oxfordshire">
-          <g id="Oxford">
-            <circle cx="71.62" cy="113.62" r="1"/>
-            <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Winchester">
+          <circle cx="72.3" cy="122.1" r="1"/>
+          <circle cx="72.3" cy="122.1" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Hertfordshire">
-          <g id="St Albans">
-            <circle cx="78.97" cy="113.62" r="1"/>
-            <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Brighton and Hove">
+          <circle cx="80.67" cy="124.93" r="1"/>
+          <circle cx="80.67" cy="124.93" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Essex">
-          <g id="Chelmsford">
-            <circle cx="85.19" cy="113.62" r="1"/>
-            <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Colchester">
-            <circle cx="88.03" cy="112.06" r="1"/>
-            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Southend-on-Sea">
-            <circle cx="86.81" cy="116.72" r="1"/>
-            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Canterbury">
+          <circle cx="89.94" cy="119.84" r="1"/>
+          <circle cx="89.94" cy="119.84" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gloucestershire">
-          <g id="Gloucester">
-            <circle cx="64.26" cy="113.05" r="1"/>
-            <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="City of Westminster">
+          <circle cx="79.54" cy="117.01" r="1"/>
+          <circle cx="79.54" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Dyfed">
-          <g id="St Davids">
-            <circle cx="43.67" cy="112.49" r="1"/>
-            <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Southend-on-Sea">
+          <circle cx="86.81" cy="116.72" r="1"/>
+          <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Herefordshire">
-          <g id="Hereford">
-            <circle cx="61.1" cy="110.79" r="1"/>
-            <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Oxford">
+          <circle cx="71.62" cy="113.62" r="1"/>
+          <circle cx="71.62" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Worcestershire">
-          <g id="Worcester">
-            <circle cx="64.83" cy="109.09" r="1"/>
-            <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Albans">
+          <circle cx="78.97" cy="113.62" r="1"/>
+          <circle cx="78.97" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cambridgeshire">
-          <g id="Cambridge">
-            <circle cx="81.23" cy="108.53" r="1"/>
-            <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ely">
-            <circle cx="81.57" cy="106.27" r="1"/>
-            <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Peterborough">
-            <circle cx="78.97" cy="104" r="1"/>
-            <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chelmsford">
+          <circle cx="85.19" cy="113.62" r="1"/>
+          <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Midlands (county)">
-          <g id="Coventry">
-            <circle cx="69.35" cy="106.27" r="1"/>
-            <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Birmingham">
-            <circle cx="67.09" cy="105.14" r="1"/>
-            <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wolverhampton">
-            <circle cx="65.39" cy="104" r="1"/>
-            <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Newport">
+          <circle cx="58.04" cy="115.88" r="1"/>
+          <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g if="Norfolk">
-          <g id="Norwich">
-            <circle cx="89.72" cy="103.44" r="1"/>
-            <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cardiff">
+          <circle cx="56.91" cy="117.01" r="1"/>
+          <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Leicestershire">
-          <g id="Leicester">
-            <circle cx="72.52" cy="103.44" r="1"/>
-            <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Swansea">
+          <circle cx="52.95" cy="114.75" r="1"/>
+          <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Staffordshire">
-          <g id="Lichfield">
-            <circle cx="67.88" cy="103.44" r="1"/>
-            <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Stoke-on-Trent">
-            <circle cx="65.39" cy="98.91" r="1"/>
-            <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Gloucester">
+          <circle cx="64.26" cy="113.05" r="1"/>
+          <circle cx="64.26" cy="113.05" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Nottinghamshire">
-          <g id="Nottingham">
-            <circle cx="72.52" cy="100.04" r="1"/>
-            <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Colchester">
+          <circle cx="88.03" cy="112.06" r="1"/>
+          <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Derbyshire">
-          <g id="Derby">
-            <circle cx="69.92" cy="99.48" r="1"/>
-            <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Davids">
+          <circle cx="43.67" cy="112.49" r="1"/>
+          <circle cx="43.67" cy="112.49" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lincolnshire">
-          <g id="Lincoln">
-            <circle cx="77.27" cy="97.78" r="1"/>
-            <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Milton Keynes">
+          <circle cx="75.50" cy="110.91" r="1"/>
+          <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Yorkshire">
-          <g id="Doncaster">
-            <circle cx="72.613" cy="92.65" r="1"/>
-            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Sheffield">
-            <circle cx="69.35" cy="94.39" r="1"/>
-            <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Hereford">
+          <circle cx="61.1" cy="110.79" r="1"/>
+          <circle cx="61.1" cy="110.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Greater Manchester">
-          <g id="Manchester">
-            <circle cx="64.83" cy="93.26" r="1"/>
-            <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Salford">
-            <circle cx="63.92" cy="93.48" r="1"/>
-            <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Worcester">
+          <circle cx="64.83" cy="109.09" r="1"/>
+          <circle cx="64.83" cy="109.09" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Merseyside">
-          <g id="Liverpool">
-            <circle cx="59.17" cy="94.39" r="1"/>
-            <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Cambridge">
+          <circle cx="81.23" cy="108.53" r="1"/>
+          <circle cx="81.23" cy="108.53" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cheshire">
-          <g id="Chester">
-            <circle cx="60.3" cy="96.65" r="1"/>
-            <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Ely">
+          <circle cx="81.57" cy="106.27" r="1"/>
+          <circle cx="81.57" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Clwyd">
-          <g id="St Asaph">
-            <circle cx="56.91" cy="96.65" r="1"/>
-            <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Wrexham">
-            <circle cx="59.30" cy="97.79" r="1"/>
-            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Coventry">
+          <circle cx="69.35" cy="106.27" r="1"/>
+          <circle cx="69.35" cy="106.27" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwynedd">
-          <g id="Bangor">
-            <circle cx="50.69" cy="96.65" r="1"/>
-            <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Birmingham">
+          <circle cx="67.09" cy="105.14" r="1"/>
+          <circle cx="67.09" cy="105.14" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="East Riding of Yorkshire">
-          <g id="Kingston upon Hull">
-            <circle cx="78.4" cy="89.3" r="1"/>
-            <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wolverhampton">
+          <circle cx="65.39" cy="104" r="1"/>
+          <circle cx="65.39" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Yorkshire">
-          <g id="Wakefield">
-            <circle cx="70.49" cy="90.99" r="1"/>
-            <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Leeds">
-            <circle cx="69.35" cy="89.3" r="1"/>
-            <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Bradford">
-            <circle cx="67.09" cy="89.3" r="1"/>
-            <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Norwich">
+          <circle cx="89.72" cy="103.44" r="1"/>
+          <circle cx="89.72" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Lancashire">
-          <g id="Preston">
-            <circle cx="61.43" cy="89.3" r="1"/>
-            <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lancaster">
-            <circle cx="61.43" cy="86.47" r="1"/>
-            <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Peterborough">
+          <circle cx="78.97" cy="104" r="1"/>
+          <circle cx="78.97" cy="104" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="North Yorkshire">
-          <g id="York">
-            <circle cx="72.75" cy="87.6" r="1"/>
-            <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Ripon">
-            <circle cx="69.92" cy="85.34" r="1"/>
-            <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Leicester">
+          <circle cx="72.52" cy="103.44" r="1"/>
+          <circle cx="72.52" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Durham">
-          <g id="Durham">
-            <circle cx="69.35" cy="78.55" r="1"/>
-            <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lichfield">
+          <circle cx="67.88" cy="103.44" r="1"/>
+          <circle cx="67.88" cy="103.44" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Tyne and Wear">
-          <g id="Sunderland">
-            <circle cx="69.92" cy="76.29" r="1"/>
-            <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Newcastle upon Tyne">
-            <circle cx="68.79" cy="75.15" r="1"/>
-            <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Nottingham">
+          <circle cx="72.52" cy="100.04" r="1"/>
+          <circle cx="72.52" cy="100.04" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Cumbria">
-          <g id="Carlisle">
-            <circle cx="60.3" cy="75.72" r="1"/>
-            <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Derby">
+          <circle cx="69.92" cy="99.48" r="1"/>
+          <circle cx="69.92" cy="99.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Buckinghamshire">
-          <g id="Milton Keynes">
-            <circle cx="75.50" cy="110.91" r="1"/>
-            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Stoke-on-Trent">
+          <circle cx="65.39" cy="98.91" r="1"/>
+          <circle cx="65.39" cy="98.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Gwent (county)">
-          <g id="Newport">
-            <circle cx="58.04" cy="115.88" r="1"/>
-            <circle cx="58.04" cy="115.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Lincoln">
+          <circle cx="77.27" cy="97.78" r="1"/>
+          <circle cx="77.27" cy="97.78" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="South Glamorgan">
-          <g id="Cardiff">
-            <circle cx="56.91" cy="117.01" r="1"/>
-            <circle cx="56.91" cy="117.01" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Sheffield">
+          <circle cx="69.35" cy="94.39" r="1"/>
+          <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="West Glamorgan">
-          <g id="Swansea">
-            <circle cx="52.95" cy="114.75" r="1"/>
-            <circle cx="52.95" cy="114.75" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Doncaster">
+          <circle cx="72.613" cy="92.65" r="1"/>
+          <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Stirling (council area)">
-          <g id="Stirling">
-            <circle cx="51.35" cy="61.00" r="1"/>
-            <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Manchester">
+          <circle cx="64.83" cy="93.26" r="1"/>
+          <circle cx="64.83" cy="93.26" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Perth and Kinross">
-          <g id="Perth">
-            <circle cx="54.72" cy="58.42" r="1"/>
-            <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Salford">
+          <circle cx="63.92" cy="93.48" r="1"/>
+          <circle cx="63.92" cy="93.48" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Highland (council area)">
-          <g id="Inverness">
-            <circle cx="49.39" cy="44.2" r="1"/>
-            <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Liverpool">
+          <circle cx="59.17" cy="94.39" r="1"/>
+          <circle cx="59.17" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="Fife">
-          <g id="Dunfermline">
-            <circle cx="55.61" cy="61.85" r="1"/>
-            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Chester">
+          <circle cx="60.3" cy="96.65" r="1"/>
+          <circle cx="60.3" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Down">
-          <g id="Bangor">
-            <circle cx="39.00" cy="79.86" r="1"/>
-            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="St Asaph">
+          <circle cx="56.91" cy="96.65" r="1"/>
+          <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Londonderry">
-          <g id="Derry">
-            <circle cx="27.11" cy="75.92" r="1"/>
-            <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wrexham">
+          <circle cx="59.30" cy="97.79" r="1"/>
+          <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh / County Down">
-          <g id="Newry">
-            <circle cx="33.87" cy="86.58" r="1"/>
-            <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Bangor, Gwynedd">
+          <circle cx="50.69" cy="96.65" r="1"/>
+          <circle cx="50.69" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Armagh">
-          <g id="Armagh">
-            <circle cx="31.45" cy="84.59" r="1"/>
-            <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Kingston upon Hull">
+          <circle cx="78.4" cy="89.3" r="1"/>
+          <circle cx="78.4" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
-        <g id="County Antrim / County Down">
-          <g id="Belfast">
-            <circle cx="36.41" cy="80.88" r="1"/>
-            <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
-          <g id="Lisburn">
-            <circle cx="34.64" cy="81.71" r="1"/>
-            <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
-          </g>
+        <g id="Wakefield">
+          <circle cx="70.49" cy="90.99" r="1"/>
+          <circle cx="70.49" cy="90.99" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Leeds">
+          <circle cx="69.35" cy="89.3" r="1"/>
+          <circle cx="69.35" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bradford">
+          <circle cx="67.09" cy="89.3" r="1"/>
+          <circle cx="67.09" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Preston">
+          <circle cx="61.43" cy="89.3" r="1"/>
+          <circle cx="61.43" cy="89.3" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lancaster">
+          <circle cx="61.43" cy="86.47" r="1"/>
+          <circle cx="61.43" cy="86.47" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="York">
+          <circle cx="72.75" cy="87.6" r="1"/>
+          <circle cx="72.75" cy="87.6" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Ripon">
+          <circle cx="69.92" cy="85.34" r="1"/>
+          <circle cx="69.92" cy="85.34" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Durham">
+          <circle cx="69.35" cy="78.55" r="1"/>
+          <circle cx="69.35" cy="78.55" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Sunderland">
+          <circle cx="69.92" cy="76.29" r="1"/>
+          <circle cx="69.92" cy="76.29" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newcastle upon Tyne">
+          <circle cx="68.79" cy="75.15" r="1"/>
+          <circle cx="68.79" cy="75.15" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Carlisle">
+          <circle cx="60.3" cy="75.72" r="1"/>
+          <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Dunfermline">
+          <circle cx="55.61" cy="61.85" r="1"/>
+          <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Stirling">
+          <circle cx="51.35" cy="61.00" r="1"/>
+          <circle cx="51.35" cy="61.00" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Perth">
+          <circle cx="54.72" cy="58.42" r="1"/>
+          <circle cx="54.72" cy="58.42" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Inverness">
+          <circle cx="49.39" cy="44.2" r="1"/>
+          <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Derry">
+          <circle cx="27.11" cy="75.92" r="1"/>
+          <circle cx="27.11" cy="75.92" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Newry">
+          <circle cx="33.87" cy="86.58" r="1"/>
+          <circle cx="33.87" cy="86.58" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Bangor, County Down">
+          <circle cx="39.00" cy="79.86" r="1"/>
+          <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Armagh">
+          <circle cx="31.45" cy="84.59" r="1"/>
+          <circle cx="31.45" cy="84.59" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Belfast">
+          <circle cx="36.41" cy="80.88" r="1"/>
+          <circle cx="36.41" cy="80.88" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+        </g>
+        <g id="Lisburn">
+          <circle cx="34.64" cy="81.71" r="1"/>
+          <circle cx="34.64" cy="81.71" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
         </g>
       </g>
       <rect id="zoomfocus" style="stroke:#F43;stroke-width:0.25;fill-opacity:0" x="40" y="59.5" width="25" height="10"/>

--- a/src/note_models/UK_Geog/templates/Map - County.html
+++ b/src/note_models/UK_Geog/templates/Map - County.html
@@ -263,6 +263,14 @@
               <circle cx="85.19" cy="113.62" r="1"/>
               <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
+            <g id="Colchester">
+              <circle cx="88.03" cy="112.06" r="1"/>
+              <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Southend-on-Sea">
+              <circle cx="86.81" cy="116.72" r="1"/>
+              <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
           </g>
           <g id="Gloucestershire">
             <g id="Gloucester">
@@ -357,6 +365,10 @@
             </g>
           </g>
           <g id="South Yorkshire">
+            <g id="Doncaster">
+              <circle cx="72.613" cy="92.65" r="1"/>
+              <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
             <g id="Sheffield">
               <circle cx="69.35" cy="94.39" r="1"/>
               <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -388,6 +400,10 @@
             <g id="St Asaph">
               <circle cx="56.91" cy="96.65" r="1"/>
               <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+            <g id="Wrexham">
+              <circle cx="59.30" cy="97.79" r="1"/>
+              <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
           </g>
           <g id="Gwynedd">
@@ -458,6 +474,12 @@
               <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
           </g>
+          <g id="Buckinghamshire">
+            <g id="Milton Keynes">
+              <circle cx="75.50" cy="110.91" r="1"/>
+              <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+          </g>
           <g id="Gwent (county)">
             <g id="Newport">
               <circle cx="58.04" cy="115.88" r="1"/>
@@ -492,6 +514,18 @@
             <g id="Inverness">
               <circle cx="49.39" cy="44.2" r="1"/>
               <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+          </g>
+          <g id="Fife">
+            <g id="Dunfermline">
+              <circle cx="55.61" cy="61.85" r="1"/>
+              <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+            </g>
+          </g>
+          <g id="County Down">
+            <g id="Bangor">
+              <circle cx="39.00" cy="79.86" r="1"/>
+              <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
             </g>
           </g>
           <g id="County Londonderry">
@@ -812,6 +846,14 @@
             <circle cx="85.19" cy="113.62" r="1"/>
             <circle cx="85.19" cy="113.62" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
+          <g id="Colchester">
+            <circle cx="88.03" cy="112.06" r="1"/>
+            <circle cx="88.03" cy="112.06" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Southend-on-Sea">
+            <circle cx="86.81" cy="116.72" r="1"/>
+            <circle cx="86.81" cy="116.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
         </g>
         <g id="Gloucestershire">
           <g id="Gloucester">
@@ -906,6 +948,10 @@
           </g>
         </g>
         <g id="South Yorkshire">
+          <g id="Doncaster">
+            <circle cx="72.613" cy="92.65" r="1"/>
+            <circle cx="72.613" cy="92.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
           <g id="Sheffield">
             <circle cx="69.35" cy="94.39" r="1"/>
             <circle cx="69.35" cy="94.39" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
@@ -937,6 +983,10 @@
           <g id="St Asaph">
             <circle cx="56.91" cy="96.65" r="1"/>
             <circle cx="56.91" cy="96.65" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+          <g id="Wrexham">
+            <circle cx="59.30" cy="97.79" r="1"/>
+            <circle cx="59.30" cy="97.79" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="Gwynedd">
@@ -1007,6 +1057,12 @@
             <circle cx="60.3" cy="75.72" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
+        <g id="Buckinghamshire">
+          <g id="Milton Keynes">
+            <circle cx="75.50" cy="110.91" r="1"/>
+            <circle cx="75.50" cy="110.91" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
         <g id="Gwent (county)">
           <g id="Newport">
             <circle cx="58.04" cy="115.88" r="1"/>
@@ -1041,6 +1097,18 @@
           <g id="Inverness">
             <circle cx="49.39" cy="44.2" r="1"/>
             <circle cx="49.39" cy="44.2" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="Fife">
+          <g id="Dunfermline">
+            <circle cx="55.61" cy="61.85" r="1"/>
+            <circle cx="55.61" cy="61.85" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
+          </g>
+        </g>
+        <g id="County Down">
+          <g id="Bangor">
+            <circle cx="39.00" cy="79.86" r="1"/>
+            <circle cx="39.00" cy="79.86" r=".6" fill-opacity="0" stroke="#fff" stroke-width=".2"/>
           </g>
         </g>
         <g id="County Londonderry">

--- a/utils/uk_geog/templates/City - County.template.html
+++ b/utils/uk_geog/templates/City - County.template.html
@@ -28,9 +28,7 @@
 --
 
 <style>
-  [id='Cities'] > :not([id='{{MacroLocation}}']),
-  [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
-  [id='Bodies of Water'] {
+  [id='Cities'] > :not([id='{{Location}}']), [id='Bodies of Water'] {
     visibility: hidden;
   }
   .info {

--- a/utils/uk_geog/templates/City - County.template.html
+++ b/utils/uk_geog/templates/City - County.template.html
@@ -1,7 +1,18 @@
 {{#City}}
+  <style>
+    .info {
+      max-width: 30em;
+      margin: 0.75em auto;
+      color: #333;
+      font-size: 90%;
+      font-style: italic;
+    }
+
+  </style>
   <header>
     <div class="type">City</div>
     <div class="value value--top">{{City}}</div>
+    {{#Info}}<div class="info">Hint: {{Info}}</div>{{/Info}}
 
     <hr>
 
@@ -22,11 +33,19 @@
   [id='Bodies of Water'] {
     visibility: hidden;
   }
+  .info {
+    max-width: 30em;
+    margin: 0.75em auto;
+    color: #333;
+    font-size: 90%;
+    font-style: italic;
+  }
 </style>
 
 <header>
   <div class="type">City</div>
   <div class="value value--top">{{City}}</div>
+  {{#Info}}<div class="info">{{Info}}</div>{{/Info}}
 
   <hr>
 

--- a/utils/uk_geog/templates/City - County.template.html
+++ b/utils/uk_geog/templates/City - County.template.html
@@ -17,7 +17,9 @@
 --
 
 <style>
-  [id='Cities'] > :not([id='{{City}}']) {
+  [id='Cities'] > :not([id='{{MacroLocation}}']),
+  [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
+  [id='Bodies of Water'] {
     visibility: hidden;
   }
 </style>

--- a/utils/uk_geog/templates/City - Map.template.html
+++ b/utils/uk_geog/templates/City - Map.template.html
@@ -15,7 +15,9 @@
 --
 
 <style>
-    [id='Cities'] > :not([id='{{City}}']) {
+    [id='Cities'] > :not([id='{{MacroLocation}}']),
+    [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
+    [id='Bodies of Water'] {
         visibility: hidden;
     }
 </style>

--- a/utils/uk_geog/templates/City - Map.template.html
+++ b/utils/uk_geog/templates/City - Map.template.html
@@ -1,7 +1,17 @@
 {{#City}}
+  <style>
+    .info {
+      max-width: 30em;
+      margin: 0.75em auto;
+      color: #333;
+      font-size: 90%;
+      font-style: italic;
+    }
+  </style>
   <header>
     <div class="type">City</div>
     <div class="value value--top">{{City}}</div>
+    {{#Info}}<div class="info">Hint: {{Info}}</div>{{/Info}}
 
     <hr>
 
@@ -20,10 +30,18 @@
     [id='Bodies of Water'] {
         visibility: hidden;
     }
+    .info {
+      max-width: 30em;
+      margin: 0.75em auto;
+      color: #333;
+      font-size: 90%;
+      font-style: italic;
+    }
 </style>
 <header>
   <div class="type">City</div>
   <div class="value value--top">{{City}}</div>
+  {{#Info}}<div class="info">{{Info}}</div>{{/Info}}
 
   <hr>
 

--- a/utils/uk_geog/templates/City - Map.template.html
+++ b/utils/uk_geog/templates/City - Map.template.html
@@ -25,9 +25,7 @@
 --
 
 <style>
-    [id='Cities'] > :not([id='{{MacroLocation}}']),
-    [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
-    [id='Bodies of Water'] {
+    [id='Cities'] > :not([id='{{Location}}']), [id='Bodies of Water'] {
         visibility: hidden;
     }
     .info {

--- a/utils/uk_geog/templates/Map - City.template.html
+++ b/utils/uk_geog/templates/Map - City.template.html
@@ -1,8 +1,6 @@
 {{#City}}
   <style>
-    [id='Cities'] > :not([id='{{MacroLocation}}']),
-    [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
-    [id='Bodies of Water'] {
+    [id='Cities'] > :not([id='{{Location}}']), [id='Bodies of Water'] {
       visibility: hidden;
     }
   </style>
@@ -25,9 +23,7 @@
 --
 
 <style>
-  [id='Cities'] > :not([id='{{MacroLocation}}']),
-  [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
-  [id='Bodies of Water'] {
+  [id='Cities'] > :not([id='{{Location}}']), [id='Bodies of Water'] {
     visibility: hidden;
   }
   .info {

--- a/utils/uk_geog/templates/Map - City.template.html
+++ b/utils/uk_geog/templates/Map - City.template.html
@@ -1,6 +1,8 @@
 {{#City}}
   <style>
-    [id='Cities'] > :not([id="{{City}}"]){
+    [id='Cities'] > :not([id='{{MacroLocation}}']),
+    [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
+    [id='Bodies of Water'] {
       visibility: hidden;
     }
   </style>
@@ -23,7 +25,9 @@
 --
 
 <style>
-  [id='Cities'] > :not([id="{{City}}"]){
+  [id='Cities'] > :not([id='{{MacroLocation}}']),
+  [id='Cities'] [id='{{MacroLocation}}'] > :not([id='{{City}}']),
+  [id='Bodies of Water'] {
     visibility: hidden;
   }
 </style>

--- a/utils/uk_geog/templates/Map - City.template.html
+++ b/utils/uk_geog/templates/Map - City.template.html
@@ -30,12 +30,20 @@
   [id='Bodies of Water'] {
     visibility: hidden;
   }
+  .info {
+    max-width: 30em;
+    margin: 0.75em auto;
+    color: #333;
+    font-size: 90%;
+    font-style: italic;
+  }
 </style>
 
 
 <header>
   <div class="type">City?</div>
   <div class="center">{{type:City}}</div>
+  {{#Info}}<div class="info">{{Info}}</div>{{/Info}}
 
   <hr>
 


### PR DESCRIPTION
Added missing mainland cities that were granted city status from 2022 onwards:
- Bangor (NI)
- Colchester
- Doncaster
- Milton Keynes
- Southend-on-Sea
- Wrexham

---

In the spirit of making the least amount of changes as possible, I pulled the SVG's from the existing notes, and added the city placements by-hand. Since the build process outputs different SVG's than what's in the deck/repo already (I've been working on making the repo output match the deck (among other fixes), which can be viewed in [this branch](https://github.com/HartBlanc/anki-uk-geography/compare/master...MisguidedEmails:anki-uk-geography:just-get-it-working?expand=1)). I've changed the SVG so the cities are grouped into `county` > `city`, and modified the CSS/style appropriately, so that the duplicate `Bangor` city name will display correctly.

This is my first time working with an Anki deck (and using crowdanki/brain-brew), so there may be some things I have missed, or done incorrectly.

Only remainder thing I would say, is perhaps adding a hint on the `Bangor` questions so that the user knows what region/area/country to answer for. Which is why I've left it as a draft currently.

Fixes: #17